### PR TITLE
Changes to ensure empty categories are also visible

### DIFF
--- a/lib/schema.ex
+++ b/lib/schema.ex
@@ -66,7 +66,7 @@ defmodule Schema do
       Enum.map(attributes, fn {name, _category} ->
         {name, category(extensions, name)}
       end)
-      |> Enum.filter(fn {_name, category} -> map_size(category[:classes]) > 0 end)
+      #|> Enum.filter(fn {_name, category} -> map_size(category[:classes]) > 0 end)
       |> Map.new()
     end)
   end


### PR DESCRIPTION
Commenting out change from an earlier [commit](https://github.com/ocsf/ocsf-server/commit/8b1d4651992952c05e34292a3039b5125e479f68) that hid empty categories.

I think we should let a user see all the available categories in OCSF, especially in the early development stages. People should know X category exists, empty or not.