### PR TITLE
Fixed ‘flickering’ on profile selection.

### DIFF
--- a/lib/schema_web/templates/page/category.html.eex
+++ b/lib/schema_web/templates/page/category.html.eex
@@ -65,5 +65,5 @@ limitations under the License.
 </div>
 
 <script>
-  init_class_profiles(true);
+  init_class_profiles();
 </script>

--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -148,6 +148,6 @@ limitations under the License.
   });
 
   init_schema_buttons();
-  init_class_profiles(true);
+  init_class_profiles();
 
 </script>

--- a/lib/schema_web/templates/page/classes.html.eex
+++ b/lib/schema_web/templates/page/classes.html.eex
@@ -57,5 +57,5 @@ limitations under the License.
   </table>
 </div>
 <script>
-  init_class_profiles(true);
+  init_class_profiles();
 </script>

--- a/lib/schema_web/templates/page/data_types.html.eex
+++ b/lib/schema_web/templates/page/data_types.html.eex
@@ -48,5 +48,5 @@ Note <strong>type<sup>O</sup></strong> denotes an observable type.
   </table>
 </div>
 <script>
-  init_class_profiles(false);
+  init_class_profiles();
 </script>

--- a/lib/schema_web/templates/page/dictionary.html.eex
+++ b/lib/schema_web/templates/page/dictionary.html.eex
@@ -57,5 +57,5 @@ limitations under the License.
   </table>
 </div>
 <script>
-  init_class_profiles(false);
+  init_class_profiles();
 </script>

--- a/lib/schema_web/templates/page/guidelines.html.eex
+++ b/lib/schema_web/templates/page/guidelines.html.eex
@@ -17,5 +17,5 @@ limitations under the License.
   <%= raw(render("guidelines_md.html")) %>
 </div>
 <script>
-  init_class_profiles(false);
+  init_class_profiles();
 </script>

--- a/lib/schema_web/templates/page/index.html.eex
+++ b/lib/schema_web/templates/page/index.html.eex
@@ -73,5 +73,5 @@ limitations under the License.
 </div>
 
 <script>
-  init_class_profiles(true);
+  init_class_profiles();
 </script>

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -20,18 +20,18 @@
   <div class="col-md">
     <h4>
       <%= @data[:caption] %>
-        
+
       <% observable = @data[:observable] %>
       <%= if is_nil(observable) do %>
       <span class="text-secondary"><sup><%= @data[:extension] || "" %></sup>
-        Object 
+        Object
       </span>
       <% else %>
       <span class="text-secondary"><sup><%= @data[:extension] || "" %></sup>
-        Observable Object 
+        Observable Object
       </span>
       <% end %>
-        
+
     </h4>
     <div class="text-secondary">
       <%= raw @data[:description] %>
@@ -112,5 +112,5 @@
 <% end %>
 <script>
   init_schema_buttons();
-  init_class_profiles(true);
+  init_class_profiles();
 </script>

--- a/lib/schema_web/templates/page/objects.html.eex
+++ b/lib/schema_web/templates/page/objects.html.eex
@@ -52,5 +52,5 @@ limitations under the License.
   </table>
 </div>
 <script>
-  init_class_profiles(true);
+  init_class_profiles();
 </script>

--- a/lib/schema_web/templates/page/schema_map.html.eex
+++ b/lib/schema_web/templates/page/schema_map.html.eex
@@ -19,5 +19,5 @@ limitations under the License.
   const main = runtime.module(define, Inspector.into(document.body));
 </script>
 <script>
-  init_class_profiles(false);
+  init_class_profiles();
 </script>

--- a/priv/static/js/profiles.js
+++ b/priv/static/js/profiles.js
@@ -16,9 +16,10 @@ function set_selected_profiles(profiles) {
   localStorage.setItem("schema_profiles", JSON.stringify(profiles));
 }
 
-function init_selected_profiles() {
-  let profiles = get_selected_profiles();
-  
+function init_selected_profiles(profiles) {
+  if (profiles == null)
+    profiles = get_selected_profiles();
+
   if (profiles.length == 0) {
     $(".oscf-class").each(function(i, e) {
       e.classList.remove('d-none');
@@ -26,8 +27,8 @@ function init_selected_profiles() {
   } else {
     $.each(profiles, function(index, element) {
       $("#" + element).prop('checked', true);
-    });  
-    
+    });
+
     $(".oscf-class").each(function(i, e) {
       let n = 0;
 
@@ -44,7 +45,7 @@ function init_selected_profiles() {
   }
 }
 
-function init_class_profiles(reload) {
+function init_class_profiles() {
   let profiles = $("#checkbox-profiles :checkbox");
   profiles.on("change", function() {
     selected_profiles = [];
@@ -52,10 +53,8 @@ function init_class_profiles(reload) {
       if (this.checked)
         selected_profiles.push(this.id)
     });
-    
-    set_selected_profiles(selected_profiles);
 
-    if (reload)
-      window.location.reload(false);
+    set_selected_profiles(selected_profiles);
+    init_selected_profiles(selected_profiles)
   });
 }


### PR DESCRIPTION
There doesn’t seem to be any need to reload the page on selection, as the only method is to set state and the reload, so by eliminating the additional step of the reload, we can set state and then re-render.

Signed-off-by: Dave Shanley <dshanley@splunk.com>