### PR TITLE
Display schema version more prominently in the browser

### DIFF
--- a/lib/schema_web/templates/layout/app.html.eex
+++ b/lib/schema_web/templates/layout/app.html.eex
@@ -121,6 +121,9 @@ limitations under the License.
     <a href=<%= Routes.static_path(@conn, "/?extensions=") %> onclick="reset_home_page()" class="navbar-brand ocsf-logo">
       <img src='<%= Routes.static_path(@conn, "/images/ocsf-logo.png") %>' alt="OCSF Logo"/>
     </a>
+    <div class="version">
+      v<%= Schema.Repo.version() %>
+    </div>
     <a class="navbar-brand" href>
       Extensions
       <hr class="divider"/>
@@ -217,6 +220,7 @@ limitations under the License.
 <div class="footer">
   Open Cybersecurity Schema Framework v<%= Schema.build_version() %>. This content includes the ICD Schema developed by Symantec, a division of Broadcom.
 </div>
+
 
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"
     integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN"

--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -220,6 +220,14 @@ li {
   background-image: linear-gradient(snow, gray);
 }
 
+/* Custom display of Version */
+.version {
+  font-weight: 600;
+  font-size: medium;
+  color: rgb(0, 0, 72);
+  background-color: lightgray;
+}
+
 .active {
   border-bottom: 2px solid #00A4B7;
 }


### PR DESCRIPTION
![Screen Shot 2023-01-19 at 10 13 48 AM](https://user-images.githubusercontent.com/89877409/213479689-eee50c4c-12b0-43c8-a2fb-d94945d9d2be.png)

Based on feedback from users, adding a div to more prominently display OCSF schema version.

Signed-off-by: rajaspa <rajaspa@amazon.com>