### PR TITLE
Add allowed headers for cors on validate endpoint

### DIFF
--- a/lib/schema_web/controllers/schema_controller.ex
+++ b/lib/schema_web/controllers/schema_controller.ex
@@ -976,6 +976,7 @@ defmodule SchemaWeb.SchemaController do
     |> put_resp_content_type("application/json")
     |> put_resp_header("access-control-allow-origin", "*")
     |> put_resp_header("access-control-allow-headers", "content-type")
+    |> put_resp_header("access-control-allow-methods", "POST, GET, OPTIONS")
     |> send_resp(error, Jason.encode!(data))
   end
 
@@ -984,6 +985,7 @@ defmodule SchemaWeb.SchemaController do
     |> put_resp_content_type("application/json")
     |> put_resp_header("access-control-allow-origin", "*")
     |> put_resp_header("access-control-allow-headers", "content-type")
+    |> put_resp_header("access-control-allow-methods", "POST, GET, OPTIONS")
     |> send_resp(200, Jason.encode!(data))
   end
 

--- a/lib/schema_web/controllers/schema_controller.ex
+++ b/lib/schema_web/controllers/schema_controller.ex
@@ -645,7 +645,7 @@ defmodule SchemaWeb.SchemaController do
   @spec json_class(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def json_class(conn, %{"id" => id} = params) do
     options = Map.get(params, "package_name") |> parse_java_package()
-    
+
     try do
       case class_ex(id, params) do
         nil ->
@@ -695,7 +695,7 @@ defmodule SchemaWeb.SchemaController do
   @spec json_object(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def json_object(conn, %{"id" => id} = params) do
     options = Map.get(params, "package_name") |> parse_java_package()
-    
+
     try do
       case object_ex(id, params) do
         nil ->
@@ -975,6 +975,7 @@ defmodule SchemaWeb.SchemaController do
     conn
     |> put_resp_content_type("application/json")
     |> put_resp_header("access-control-allow-origin", "*")
+    |> put_resp_header("access-control-allow-headers", "content-type")
     |> send_resp(error, Jason.encode!(data))
   end
 
@@ -982,6 +983,7 @@ defmodule SchemaWeb.SchemaController do
     conn
     |> put_resp_content_type("application/json")
     |> put_resp_header("access-control-allow-origin", "*")
+    |> put_resp_header("access-control-allow-headers", "content-type")
     |> send_resp(200, Jason.encode!(data))
   end
 
@@ -1066,7 +1068,7 @@ defmodule SchemaWeb.SchemaController do
     |> Enum.map(fn s -> String.trim(s) end)
     |> MapSet.new()
   end
-  
+
   defp parse_java_package(nil), do: []
   defp parse_java_package(""), do: []
   defp parse_java_package(name), do: [package_name: name]


### PR DESCRIPTION
The following PR adds the `Access-Control-Allow-Headers`. Otherwise, the validation endpoint cannot be used from a browser context.

In order to use the endpoint, setting the `Content-Type` header is necessary, otherwise not the correct result will be returned. When sending a CORS POST request with `Content-Type: application/json` to the `/validate` endpoint, the request is preflighted and will fail because the server does not allow the `Content-Type` header to be submitted as part of the subsequent CORS request.
