### PR TITLE
Available versions endpoint

### DIFF
--- a/lib/schema_web/controllers/schema_controller.ex
+++ b/lib/schema_web/controllers/schema_controller.ex
@@ -149,7 +149,10 @@ defmodule SchemaWeb.SchemaController do
 
   @spec versions(Plug.Conn.t(), any) :: Plug.Conn.t()
   def versions(conn, _params) do
-    base_url = "#{conn.scheme}://#{conn.host}:#{conn.port}"
+
+    url = Application.get_env(:schema_server, SchemaWeb.Endpoint)[:url]
+
+    base_url = "#{conn.scheme}://#{Keyword.fetch!(url, :host)}:#{Keyword.fetch!(url, :port)}"
 
     available_versions = Schemas.versions()
     |> Enum.map(fn {version, _} -> version end)
@@ -163,7 +166,7 @@ defmodule SchemaWeb.SchemaController do
 
       [_head | _tail] ->
         available_versions_objects = available_versions
-        |> Enum.map(fn version -> %{:version => version, :url => "#{conn.scheme}://#{conn.host}:#{conn.port}/#{version}/api"} end)
+        |> Enum.map(fn version -> %{:version => version, :url => "#{base_url}/#{version}/api"} end)
         %{:versions => available_versions_objects, :default => default_version}
 
     end

--- a/lib/schema_web/controllers/schema_controller.ex
+++ b/lib/schema_web/controllers/schema_controller.ex
@@ -53,7 +53,20 @@ defmodule SchemaWeb.SchemaController do
           end
 
           example(%{
-            versions: ["1.0.0", "1.1.0"]
+            default: %{
+              version: "1.0.0",
+              url: "https://schema.example.com:443/api"
+            },
+            versions: [
+              %{
+                version: "1.1.0-dev",
+                url: "https://schema.example.com:443/1.1.0-dev/api"
+              },
+              %{
+                version: "1.0.0",
+                url: "https://schema.example.com:443/1.0.0/api"
+              }
+            ]
           })
         end,
       ClassDesc:

--- a/lib/schema_web/controllers/schema_controller.ex
+++ b/lib/schema_web/controllers/schema_controller.ex
@@ -165,12 +165,17 @@ defmodule SchemaWeb.SchemaController do
 
     url = Application.get_env(:schema_server, SchemaWeb.Endpoint)[:url]
 
-    base_url = "#{conn.scheme}://#{Keyword.fetch!(url, :host)}:#{Keyword.fetch!(url, :port)}"
+    # The :url key is meant to be set for production, but isn't set for local development
+    base_url = if url == nil do
+      "#{conn.scheme}://#{conn.host}:#{conn.port}"
+    else
+      "#{conn.scheme}://#{Keyword.fetch!(url, :host)}:#{Keyword.fetch!(url, :port)}"
+    end
 
     available_versions = Schemas.versions()
     |> Enum.map(fn {version, _} -> version end)
 
-    default_version = %{:version => Schema.version(), :url => "#{base_url}/api"}
+    default_version = %{:version => Schema.version(), :url => "#{base_url}/#{Schema.version()}/api"}
 
     versions_response = case available_versions do
       [] ->

--- a/lib/schema_web/controllers/schema_controller.ex
+++ b/lib/schema_web/controllers/schema_controller.ex
@@ -154,12 +154,23 @@ defmodule SchemaWeb.SchemaController do
     |> Enum.map(fn {version, _} -> version end)
 
 
+    default_version = %{:version => Schema.version(), :url => "/api"}
+
     versions_response = case available_versions do
       [] ->
         # If there is no response, we only provide a single schema
-        %{:versions => [Schema.version()]}
+        %{:versions => [%{:version => Schema.version(), :url => "/api"}], :default => default_version}
+
       [_head | _tail] ->
-        %{:versions => available_versions}
+
+        available_versions_objects = available_versions
+        |> Enum.map(fn version -> %{:version => version, :url => "/#{version}/api"} end)
+
+
+        url = Application.get_env(:schema_server, SchemaWeb.Endpoint)[:url]
+
+        %{:versions => available_versions_objects, :default => default_version}
+
     end
 
     send_json_resp(conn, versions_response)

--- a/lib/schema_web/controllers/schema_controller.ex
+++ b/lib/schema_web/controllers/schema_controller.ex
@@ -149,26 +149,21 @@ defmodule SchemaWeb.SchemaController do
 
   @spec versions(Plug.Conn.t(), any) :: Plug.Conn.t()
   def versions(conn, _params) do
+    base_url = "#{conn.scheme}://#{conn.host}:#{conn.port}"
 
     available_versions = Schemas.versions()
     |> Enum.map(fn {version, _} -> version end)
 
-
-    default_version = %{:version => Schema.version(), :url => "/api"}
+    default_version = %{:version => Schema.version(), :url => "#{base_url}/api"}
 
     versions_response = case available_versions do
       [] ->
         # If there is no response, we only provide a single schema
-        %{:versions => [%{:version => Schema.version(), :url => "/api"}], :default => default_version}
+        %{:versions => [default_version], :default => default_version}
 
       [_head | _tail] ->
-
         available_versions_objects = available_versions
-        |> Enum.map(fn version -> %{:version => version, :url => "/#{version}/api"} end)
-
-
-        url = Application.get_env(:schema_server, SchemaWeb.Endpoint)[:url]
-
+        |> Enum.map(fn version -> %{:version => version, :url => "#{conn.scheme}://#{conn.host}:#{conn.port}/#{version}/api"} end)
         %{:versions => available_versions_objects, :default => default_version}
 
     end

--- a/lib/schema_web/controllers/schema_controller.ex
+++ b/lib/schema_web/controllers/schema_controller.ex
@@ -123,6 +123,28 @@ defmodule SchemaWeb.SchemaController do
   end
 
   @doc """
+  Get available OCSF schema versions.
+  """
+  swagger_path :versions do
+    get("/api/versions")
+    summary("Versions")
+    description("Get available OCSF schema versions.")
+    produces("application/json")
+    tag("Schema")
+    response(200, "Success", :Version)
+  end
+
+  @spec versions(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def versions(conn, _params) do
+
+    available_versions = Schemas.versions()
+    |> Enum.map(fn {version, _} -> version end)
+
+    versions_response = %{:versions => available_versions}
+    send_json_resp(conn, versions_response)
+  end
+
+  @doc """
   Get the schema data types.
   """
   swagger_path :data_types do

--- a/lib/schema_web/controllers/schema_controller.ex
+++ b/lib/schema_web/controllers/schema_controller.ex
@@ -140,7 +140,15 @@ defmodule SchemaWeb.SchemaController do
     available_versions = Schemas.versions()
     |> Enum.map(fn {version, _} -> version end)
 
-    versions_response = %{:versions => available_versions}
+
+    versions_response = case available_versions do
+      [] ->
+        # If there is no response, we only provide a single schema
+        %{:versions => [Schema.version()]}
+      [_head | _tail] ->
+        %{:versions => available_versions}
+    end
+
     send_json_resp(conn, versions_response)
   end
 

--- a/lib/schema_web/controllers/schema_controller.ex
+++ b/lib/schema_web/controllers/schema_controller.ex
@@ -43,6 +43,19 @@ defmodule SchemaWeb.SchemaController do
             version: "1.0.0"
           })
         end,
+      Versions:
+        swagger_schema do
+          title("Versions")
+          description("Schema versions, using Semantic Versioning Specification (SemVer) format.")
+
+          properties do
+            versions(:string, "Version numbers", required: true)
+          end
+
+          example(%{
+            versions: ["1.0.0", "1.1.0"]
+          })
+        end,
       ClassDesc:
         swagger_schema do
           title("Class Descriptor")
@@ -131,7 +144,7 @@ defmodule SchemaWeb.SchemaController do
     description("Get available OCSF schema versions.")
     produces("application/json")
     tag("Schema")
-    response(200, "Success", :Version)
+    response(200, "Success", :Versions)
   end
 
   @spec versions(Plug.Conn.t(), any) :: Plug.Conn.t()

--- a/lib/schema_web/router.ex
+++ b/lib/schema_web/router.ex
@@ -38,7 +38,7 @@ defmodule SchemaWeb.Router do
     get "/classes", PageController, :classes
     get "/classes/:id", PageController, :classes
     get "/classes/:extension/:id", PageController, :classes
-    
+
     get "/class/graph/:id", PageController, :class_graph
     get "/class/graph/:extension/:id", PageController, :class_graph
 
@@ -51,7 +51,7 @@ defmodule SchemaWeb.Router do
 
     get "/object/graph/:id", PageController, :object_graph
     get "/object/graph/:extension/:id", PageController, :object_graph
-    
+
     get "/data_types", PageController, :data_types
     get "/guidelines", PageController, :guidelines
   end
@@ -61,6 +61,8 @@ defmodule SchemaWeb.Router do
     pipe_through :api
 
     get "/version", SchemaController, :version
+    get "/versions", SchemaController, :versions
+
     get "/profiles", SchemaController, :profiles
     get "/extensions", SchemaController, :extensions
 
@@ -94,7 +96,7 @@ defmodule SchemaWeb.Router do
 
     get "/classes/:id", SchemaController, :json_class
     get "/classes/:extension/:id", SchemaController, :json_class
-    
+
     get "/objects/:id", SchemaController, :json_object
     get "/objects/:extension/:id", SchemaController, :json_object
   end


### PR DESCRIPTION
This PR adds a new `api/versions` endpoint. It returns all schemas that are available on the schema server instance.

The response is in the following format:
```
{"versions":["1.0.0-rc.3","1.1.0-dev"]}
```