### PR TITLE
Add option to filter recommended fields in the server

### DIFF
--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -64,6 +64,7 @@ limitations under the License.
               </optgroup>
               <optgroup id="requirements-select" label="Requirements">
                 <option class="optional" value="optional" title="Optional">Optional Attributes</option>
+                <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
               </optgroup>
             </select>
           </li>

--- a/lib/schema_web/templates/page/class_graph.html.eex
+++ b/lib/schema_web/templates/page/class_graph.html.eex
@@ -54,6 +54,7 @@ limitations under the License.
               </optgroup>
               <optgroup id="requirements-select" label="Requirements">
                 <option class="optional" value="optional" title="Optional">Optional Attributes</option>
+                <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
               </optgroup>
             </select>
           </li>
@@ -67,7 +68,7 @@ limitations under the License.
 <script type="text/javascript" src='<%= Routes.static_path(@conn, "/js/vis-network.min.js") %>'></script>
 <script type="text/javascript">
   init_class_profiles();
-  
+
   let container = document.getElementById("network");
   let data = <%= raw Jason.encode!(@data) %>;
   let options = {

--- a/lib/schema_web/templates/page/guidelines_md.html.md
+++ b/lib/schema_web/templates/page/guidelines_md.html.md
@@ -10,9 +10,6 @@ Attributes that are most common across all use cases are defined as core attribu
 *Optional Attributes*
 Optional attributes may apply to more narrow use cases, or may be more open to interpretation depending on the use case. The optional attributes are marked as **Optional**.
 
-*Reserved Attributes*
-Reserved attributes are set by the logging system and must not be used in the event data. The reserved attributes are marked as **Reserved**.
-
 ## Guidelines for attribute names
 - Attribute names must be a valid UTF-8 sequence.
 

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -39,7 +39,7 @@
         <% end %>
       </span>
     </h3>
-    
+
     <div class="text-secondary">
       <%= raw description(@data) %>
     </div>
@@ -58,6 +58,7 @@
               data-width="auto">
               <optgroup id="requirements-select" label="Requirements">
                 <option class="optional" value="optional" title="Optional">Optional Attributes</option>
+                <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
               </optgroup>
             </select>
           </li>

--- a/lib/schema_web/templates/page/object_graph.html.eex
+++ b/lib/schema_web/templates/page/object_graph.html.eex
@@ -24,7 +24,7 @@ limitations under the License.
       <% end %>
       object
     </h3>
-    
+
     <div class="text-secondary">
       <%= raw class[:description] %>
     </div>
@@ -44,6 +44,7 @@ limitations under the License.
               data-width="auto">
               <optgroup id="requirements-select" label="Requirements">
                 <option class="optional" value="optional" title="Optional">Optional Attributes</option>
+                <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
               </optgroup>
             </select>
           </li>
@@ -57,7 +58,7 @@ limitations under the License.
 <script type="text/javascript" src='<%= Routes.static_path(@conn, "/js/vis-network.min.js") %>'></script>
 <script type="text/javascript">
   init_class_profiles();
-  
+
    let container = document.getElementById("network");
    let data = <%= raw Jason.encode!(@data) %>;
    let options = {
@@ -77,6 +78,6 @@ limitations under the License.
        // solver: 'repulsion',
      },
    };
-   
+
    new vis.Network(container, data, options);
 </script>

--- a/lib/schema_web/templates/page/profile.html.eex
+++ b/lib/schema_web/templates/page/profile.html.eex
@@ -18,7 +18,7 @@
         Profile
       </span>
     </h3>
-    
+
     <div class="text-secondary">
       <%= raw @data[:description] %>
     </div>
@@ -43,6 +43,7 @@
               </optgroup>
               <optgroup id="requirements-select" label="Requirements">
                 <option class="optional" value="optional" title="Optional">Optional Attributes</option>
+                <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
               </optgroup>
             </select>
           </li>

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -71,12 +71,12 @@ defmodule SchemaWeb.PageView do
   defp profile_link(_conn, nil, name) do
     name
   end
-  
+
   defp profile_link(conn, caption, name) do
     path = Routes.static_path(conn, "/profiles/" <> name)
     "<a href='#{path}'>#{caption}</a>"
   end
-  
+
   def class_examples(class) do
     format_class_examples(class[:examples])
   end
@@ -166,7 +166,11 @@ defmodule SchemaWeb.PageView do
       if required?(field) do
         base <> "required "
       else
-        base <> "optional "
+        if recommended?(field) do
+        base <> "recommended "
+        else
+          base <> "optional "
+        end
       end
 
     group = field[:group]
@@ -189,7 +193,12 @@ defmodule SchemaWeb.PageView do
 
   defp required?(field) do
     r = Map.get(field, :requirement)
-    r == "required" or r == "recommended"
+    r == "required"
+  end
+
+  defp recommended?(field) do
+    r = Map.get(field, :requirement)
+    r == "recommended"
   end
 
   def format_constraints(:string_t, field) do
@@ -490,11 +499,11 @@ defmodule SchemaWeb.PageView do
   def description(map) do
     deprecated(map, Map.get(map, :"@deprecated"))
   end
-  
+
   defp deprecated(map, nil) do
     Map.get(map, :description)
   end
-  
+
   defp deprecated(map, deprecated) do
     [
       Map.get(map, :description),

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.58.0"
+  @version "2.59.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -37,7 +37,7 @@ function set_selected_extensions(extensions) {
   localStorage.setItem("schema_extensions", JSON.stringify(extensions));
 }
 
-const defaultSelectedValues = ["base-event", "optional", "classification", "context", "occurrence", "primary"];
+const defaultSelectedValues = ["base-event", "optional", "recommended", "classification", "context", "occurrence", "primary"];
 const storageKey = "selected-attributes"
 
 function hide(name) {


### PR DESCRIPTION
Related issue - https://github.com/ocsf/ocsf-server/issues/47

Changes made - 
1. Adding Recommended Attribute selection to all templates
2. Adding a function to determine if a field is recommended or not
3. Adding recommended fields to the default view selection

---
An unrelated change, updating guidelines.md to remove references to `reserved` attributes - a deprecated concept. In general, I am not sure if this page adds any value at all, the contents are already a part of the contribution guide, perhaps we can remove it all together.

Recommended Attributes Selected -  

![Screenshot 2023-10-18 at 3 52 55 PM](https://github.com/ocsf/ocsf-server/assets/89877409/cf65ecb2-bcfb-4281-aa9f-b73ab0728d3f)

Recommended Attributes de-Selected -  

![Screenshot 2023-10-18 at 3 53 05 PM](https://github.com/ocsf/ocsf-server/assets/89877409/843cb0ee-7c17-4781-8404-8607a6668391)
