### PR TITLE
#46 Add a Functioning Deprecated filter

### DIFF
--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -61,6 +61,7 @@ limitations under the License.
                 <option selected value="context">Context</option>
                 <option selected value="occurrence">Occurrence</option>
                 <option selected value="primary">Primary</option>
+                <option selected value="deprecated">Deprecated</option>
               </optgroup>
               <optgroup id="requirements-select" label="Requirements">
                 <option class="optional" value="optional" title="Optional">Optional Attributes</option>
@@ -86,6 +87,7 @@ limitations under the License.
       <th style="width: 10%">Requirement</th>
       <th style="width: 10%">Type</th>
       <th style="width: 50%">Description</th>
+      <th style="display:none">Deprecated</th>
     </tr>
     </thead>
     <tbody class="searchable">

--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -87,7 +87,6 @@ limitations under the License.
       <th style="width: 10%">Requirement</th>
       <th style="width: 10%">Type</th>
       <th style="width: 50%">Description</th>
-      <th style="display:none">Deprecated</th>
     </tr>
     </thead>
     <tbody class="searchable">

--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -56,6 +56,7 @@ limitations under the License.
               <option selected id="base-event-select" class="base-event" value="base-event" title="Base Event">Base
                 Event Attributes
               </option>
+              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
               <optgroup id="groups-select" label="Groups">
                 <option selected value="classification">Classification</option>
                 <option selected value="context">Context</option>
@@ -64,7 +65,6 @@ limitations under the License.
               </optgroup>
               <optgroup id="requirements-select" label="Requirements">
                 <option class="optional" value="optional" title="Optional">Optional Attributes</option>
-                <option class="deprecated" value="deprecated" title="Deprecated">Deprecated Attributes</option>
               </optgroup>
             </select>
           </li>

--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -61,11 +61,11 @@ limitations under the License.
                 <option selected value="context">Context</option>
                 <option selected value="occurrence">Occurrence</option>
                 <option selected value="primary">Primary</option>
-                <option selected value="deprecated">Deprecated</option>
               </optgroup>
               <optgroup id="requirements-select" label="Requirements">
                 <option class="optional" value="optional" title="Optional">Optional Attributes</option>
               </optgroup>
+              <option selected value="deprecated">Deprecated Attributes</option>
             </select>
           </li>
           <li class="nav-item">

--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -64,8 +64,8 @@ limitations under the License.
               </optgroup>
               <optgroup id="requirements-select" label="Requirements">
                 <option class="optional" value="optional" title="Optional">Optional Attributes</option>
+                <option class="deprecated" value="deprecated" title="Deprecated">Deprecated Attributes</option>
               </optgroup>
-              <option selected value="deprecated">Deprecated Attributes</option>
             </select>
           </li>
           <li class="nav-item">

--- a/lib/schema_web/templates/page/class_graph.html.eex
+++ b/lib/schema_web/templates/page/class_graph.html.eex
@@ -43,6 +43,7 @@ limitations under the License.
               data-selected-text-format="count > 3"
               data-actions-box="true"
               data-width="auto">
+              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
               <option selected id="base-event-select" class="base-event" value="base-event" title="Base Event">Base
                 Event Attributes
               </option>

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -80,7 +80,6 @@
         <th style="width: 8%">Requirement</th>
         <th style="width: 8%">Type</th>
         <th style="width: 30%">Description</th>
-        <th style="display:none">Deprecated</th>
       </tr>
     </thead>
     <tbody class="searchable">

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -56,11 +56,9 @@
               data-selected-text-format="count > 3"
               data-actions-box="true"
               data-width="auto">
+              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
               <optgroup id="requirements-select" label="Requirements">
                 <option class="optional" value="optional" title="Optional">Optional Attributes</option>
-              </optgroup>
-                <option class="deprecated" value="deprecated" title="Deprecated">Deprecated Attributes</option>
-              <optgroup id="deprecation-select" label="Deprecation">
               </optgroup>
             </select>
           </li>

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -59,6 +59,9 @@
               <optgroup id="requirements-select" label="Requirements">
                 <option class="optional" value="optional" title="Optional">Optional Attributes</option>
               </optgroup>
+                <option class="deprecated" value="deprecated" title="Deprecated">Deprecated Attributes</option>
+              <optgroup id="deprecation-select" label="Deprecation">
+              </optgroup>
             </select>
           </li>
           <li class="nav-item">
@@ -79,6 +82,7 @@
         <th style="width: 8%">Requirement</th>
         <th style="width: 8%">Type</th>
         <th style="width: 30%">Description</th>
+        <th style="display:none">Deprecated</th>
       </tr>
     </thead>
     <tbody class="searchable">

--- a/lib/schema_web/templates/page/profile.html.eex
+++ b/lib/schema_web/templates/page/profile.html.eex
@@ -35,6 +35,7 @@
               data-selected-text-format="count > 3"
               data-actions-box="true"
               data-width="auto">
+              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
               <optgroup id="groups-select" label="Groups">
                 <option selected value="classification">Classification</option>
                 <option selected value="context">Context</option>

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -162,11 +162,18 @@ defmodule SchemaWeb.PageView do
         "event "
       end
 
+    deprecated =
+      if field[:"@deprecated"] != nil do
+        base <> "deprecated "
+      else
+        base <> "not-deprecated "
+      end
+
     classes =
       if required?(field) do
-        base <> "required "
+        deprecated <> "required "
       else
-        base <> "optional "
+        deprecated <> "optional "
       end
 
     group = field[:group]
@@ -180,17 +187,10 @@ defmodule SchemaWeb.PageView do
 
     profile = field[:profile]
 
-    profiles =
-      if profile != nil do
-        classes <> " " <> String.replace(profile, "/", "-")
-      else
-        classes <> " no-profile"
-      end
-
-    if field[:"@deprecated"] != nil do
-      profiles <> " deprecated "
+    if profile != nil do
+      classes <> " " <> String.replace(profile, "/", "-")
     else
-      profiles <> ""
+      classes <> " no-profile"
     end
   end
 

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -71,12 +71,12 @@ defmodule SchemaWeb.PageView do
   defp profile_link(_conn, nil, name) do
     name
   end
-  
+
   defp profile_link(conn, caption, name) do
     path = Routes.static_path(conn, "/profiles/" <> name)
     "<a href='#{path}'>#{caption}</a>"
   end
-  
+
   def class_examples(class) do
     format_class_examples(class[:examples])
   end
@@ -185,11 +185,20 @@ defmodule SchemaWeb.PageView do
     else
       classes <> " no-profile"
     end
+
+    if deprecated?(field) do
+      classes <> " deprecated "
+    end
+
   end
 
   defp required?(field) do
     r = Map.get(field, :requirement)
     r == "required" or r == "recommended"
+  end
+
+  defp deprecated?(field) do
+    Map.get(field, :"@deprecated")
   end
 
   def format_constraints(:string_t, field) do
@@ -490,11 +499,11 @@ defmodule SchemaWeb.PageView do
   def description(map) do
     deprecated(map, Map.get(map, :"@deprecated"))
   end
-  
+
   defp deprecated(map, nil) do
     Map.get(map, :description)
   end
-  
+
   defp deprecated(map, deprecated) do
     [
       Map.get(map, :description),

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -180,27 +180,23 @@ defmodule SchemaWeb.PageView do
 
     profile = field[:profile]
 
-    if profile != nil do
-      classes <> " " <> String.replace(profile, "/", "-")
-    else
-      classes <> " no-profile"
-    end
+    profiles =
+      if profile != nil do
+        classes <> " " <> String.replace(profile, "/", "-")
+      else
+        classes <> " no-profile"
+      end
 
-    if deprecated?(field) do
-      classes <> " deprecated "
+    if field[:"@deprecated"] != nil do
+      profiles <> " deprecated "
     else
-      classes <> " "
+      profiles <> ""
     end
-
   end
 
   defp required?(field) do
     r = Map.get(field, :requirement)
     r == "required" or r == "recommended"
-  end
-
-  defp deprecated?(field) do
-    Map.get(field, :"@deprecated")
   end
 
   def format_constraints(:string_t, field) do

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -188,6 +188,8 @@ defmodule SchemaWeb.PageView do
 
     if deprecated?(field) do
       classes <> " deprecated "
+    else
+      classes <> " "
     end
 
   end

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.58.0"
+  @version "2.60.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -99,6 +99,7 @@ function display_attributes(options) {
   if (table != null) {
     // add classes that are always shown
     options.add("event");
+    options.add("not-deprecated")
     options.add("required");
     options.add("no-group");
     options.add("no-profile");
@@ -133,7 +134,7 @@ function intersection(setA, setB) {
 }
 
 function display_row(set, classList) {
-  if (set.size == 4)
+  if (set.size == 5)
     classList.remove('d-none');
   else
     classList.add('d-none');

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -37,7 +37,7 @@ function set_selected_extensions(extensions) {
   localStorage.setItem("schema_extensions", JSON.stringify(extensions));
 }
 
-const defaultSelectedValues = ["base-event", "optional", "classification", "context", "occurrence", "primary"];
+const defaultSelectedValues = ["base-event", "optional", "classification", "context", "occurrence", "primary", "deprecated"];
 const storageKey = "selected-attributes"
 
 function hide(name) {


### PR DESCRIPTION
This PR addresses issue #46 to add a Functioning filter to the dropdown menu to hide/unhide Deprecate Attributes:

With `Deprecated` selected:

<img width="1251" alt="image" src="https://github.com/ocsf/ocsf-server/assets/91983279/46f1ddb2-8f0b-4648-ba2f-549bcc72cc9a">

With `Deprecated` deselected:

<img width="1202" alt="image" src="https://github.com/ocsf/ocsf-server/assets/91983279/b9ad4d0a-edc3-45cc-849a-09175b3d0886">
