### PR TITLE
Add a Deprecated filter

### DIFF
--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -56,6 +56,7 @@ limitations under the License.
               <option selected id="base-event-select" class="base-event" value="base-event" title="Base Event">Base
                 Event Attributes
               </option>
+              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
               <optgroup id="groups-select" label="Groups">
                 <option selected value="classification">Classification</option>
                 <option selected value="context">Context</option>

--- a/lib/schema_web/templates/page/class_graph.html.eex
+++ b/lib/schema_web/templates/page/class_graph.html.eex
@@ -46,6 +46,7 @@ limitations under the License.
               <option selected id="base-event-select" class="base-event" value="base-event" title="Base Event">Base
                 Event Attributes
               </option>
+              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
               <optgroup id="groups-select" label="Groups">
                 <option selected value="classification">Classification</option>
                 <option selected value="context">Context</option>

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -56,6 +56,7 @@
               data-selected-text-format="count > 3"
               data-actions-box="true"
               data-width="auto">
+              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
               <optgroup id="requirements-select" label="Requirements">
                 <option class="optional" value="optional" title="Optional">Optional Attributes</option>
                 <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>

--- a/lib/schema_web/templates/page/object_graph.html.eex
+++ b/lib/schema_web/templates/page/object_graph.html.eex
@@ -42,6 +42,7 @@ limitations under the License.
               data-selected-text-format="count > 3"
               data-actions-box="true"
               data-width="auto">
+              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
               <optgroup id="requirements-select" label="Requirements">
                 <option class="optional" value="optional" title="Optional">Optional Attributes</option>
                 <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>

--- a/lib/schema_web/templates/page/profile.html.eex
+++ b/lib/schema_web/templates/page/profile.html.eex
@@ -35,6 +35,7 @@
               data-selected-text-format="count > 3"
               data-actions-box="true"
               data-width="auto">
+              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
               <optgroup id="groups-select" label="Groups">
                 <option selected value="classification">Classification</option>
                 <option selected value="context">Context</option>

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -162,14 +162,21 @@ defmodule SchemaWeb.PageView do
         "event "
       end
 
+    deprecation_status =
+      if field[:"@deprecated"] != nil do
+        base <> "deprecated "
+      else
+        base <> "not-deprecated "
+      end
+
     classes =
       if required?(field) do
-        base <> "required "
+        deprecation_status <> "required "
       else
         if recommended?(field) do
-        base <> "recommended "
+          deprecation_status <> "recommended "
         else
-          base <> "optional "
+          deprecation_status <> "optional "
         end
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.59.0"
+  @version "2.60.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -37,7 +37,7 @@ function set_selected_extensions(extensions) {
   localStorage.setItem("schema_extensions", JSON.stringify(extensions));
 }
 
-const defaultSelectedValues = ["base-event", "optional", "recommended", "classification", "context", "occurrence", "primary"];
+const defaultSelectedValues = ["base-event", "deprecated", "optional", "recommended", "classification", "context", "occurrence", "primary"];
 const storageKey = "selected-attributes"
 
 function hide(name) {
@@ -99,6 +99,7 @@ function display_attributes(options) {
   if (table != null) {
     // add classes that are always shown
     options.add("event");
+    options.add("not-deprecated")
     options.add("required");
     options.add("no-group");
     options.add("no-profile");
@@ -133,7 +134,7 @@ function intersection(setA, setB) {
 }
 
 function display_row(set, classList) {
-  if (set.size == 4)
+  if (set.size == 5)
     classList.remove('d-none');
   else
     classList.add('d-none');


### PR DESCRIPTION
This PR addresses issue #46 to add a Functioning filter to the dropdown menu to hide/unhide Deprecate Attributes:

### Class View example:

- `Deprecated` selected:

<img width="1251" alt="image" src="https://github.com/ocsf/ocsf-server/assets/91983279/46f1ddb2-8f0b-4648-ba2f-549bcc72cc9a">

- `Deprecated` de-selected:

<img width="1202" alt="image" src="https://github.com/ocsf/ocsf-server/assets/91983279/b9ad4d0a-edc3-45cc-849a-09175b3d0886">

### Object View example:

- `Deprecated` selected:

<img width="1556" alt="image" src="https://github.com/ocsf/ocsf-server/assets/91983279/7f146ba0-b7a3-422d-bc76-9869a588221f">

- `Deprecated` de-selected:

<img width="1551" alt="image" src="https://github.com/ocsf/ocsf-server/assets/91983279/32af9208-39c6-4850-bce9-6bde0e13a8f6">
