### PR TITLE
Display schema version since deprecation of an attribute

### DIFF
--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -514,9 +514,10 @@ defmodule SchemaWeb.PageView do
   defp deprecated(map, deprecated) do
     [
       Map.get(map, :description),
-      "<div class='text-dark mt-2'><span class='bg-warning'>DEPRECATED</span> ",
-      Map.get(deprecated, :message),
-      "</div>"
+      "<div class='text-dark mt-2'><span class='bg-warning'>DEPRECATED since ",
+      Map.get(deprecated, :since),
+      "</span></div>",
+      Map.get(deprecated, :message)
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.61.0"
+  @version "2.62.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"


### PR DESCRIPTION
In the JSON definition files, we add a deprecated flag as stated below - 
```
      "@deprecated": {
        "message": "Use the <code> evidences </code> attribute instead.",
        "since": "v1.1.0"
      },
```

However, in the server we never displayed the version number since a field/object/class is deprecated. With this change, the server will now display the version as well.

Before-
![Screenshot 2023-11-22 at 10 46 25 AM](https://github.com/ocsf/ocsf-server/assets/89877409/ce23e964-7c64-4326-826c-9b751c2da163)

After-
![Screenshot 2023-11-22 at 10 44 41 AM](https://github.com/ocsf/ocsf-server/assets/89877409/644e1ff6-3141-49c2-b18d-97bb20ebb489)

