### PR TITLE
Display "v" prefix for version values

### DIFF
--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -514,7 +514,7 @@ defmodule SchemaWeb.PageView do
   defp deprecated(map, deprecated) do
     [
       Map.get(map, :description),
-      "<div class='text-dark mt-2'><span class='bg-warning'>DEPRECATED since ",
+      "<div class='text-dark mt-2'><span class='bg-warning'>DEPRECATED since v",
       Map.get(deprecated, :since),
       "</span></div>",
       Map.get(deprecated, :message)

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.63.0"
+  @version "2.64.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"


### PR DESCRIPTION
Minor change, display "v" for version values in the `since` key added via the @deprecated tag. 

Followup - a PR in ocsf-schema repo to clean up all the instances of @deprecated tag and remove "v" from version values.