### PR TITLE
Adding a link to the Extensions registry in the server

### DIFF
--- a/lib/schema_web/templates/layout/app.html.eex
+++ b/lib/schema_web/templates/layout/app.html.eex
@@ -137,7 +137,7 @@ limitations under the License.
     </script>
 
     <div class="navbar-brand">
-      Extensions
+      <a target="_blank" href=https://github.com/ocsf/ocsf-schema/blob/main/extensions.md>Extensions</a>
       <hr class="divider"/>
     </div>
     <div class="collapse navbar-collapse" id="checkbox-extensions">

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.64.0"
+  @version "2.65.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"


### PR DESCRIPTION
A simple change, the [extensions registry](https://github.com/ocsf/ocsf-schema/blob/main/extensions.md) is not currently referenced in the server at all making it harder for people to understand values while populating `metadata.extensions`.

Adding a link to that page here - 
![image](https://github.com/ocsf/ocsf-server/assets/89877409/866036cf-7f51-4cae-bc81-a0f4a36dabfb)
