### PR TITLE
Disabling older examples linking function, adding a button for json-schema

### DIFF
--- a/lib/schema_web/templates/layout/app.html.eex
+++ b/lib/schema_web/templates/layout/app.html.eex
@@ -209,6 +209,7 @@ limitations under the License.
           Resources
           <div class="dropdown-content">
             <a class="nav-link" target="_blank" href="https://github.com/ocsf/ocsf-docs/blob/main/Understanding%20OCSF.pdf">Understanding OCSF</a>
+            <a class="nav-link" target="_blank" href="https://github.com/ocsf/examples/tree/main">Example Mappings</a>
             <a class="nav-link" target="_blank" href="https://github.com/ocsf/ocsf-schema/blob/main/CONTRIBUTING.md">Contributing to OCSF</a>
             <a class="nav-link" href='<%= Routes.static_path(@conn, "/data_types") %>'>OCSF Data Types</a>
             <a class="nav-link" target="_blank" href='<%= Routes.static_path(@conn, "/doc") %>'>API Documentation</a>
@@ -218,7 +219,12 @@ limitations under the License.
 
       <li class="nav-item">
         <div id="json-schema" class="d-none">
-          <button type="button" id="btn-json-schema" class="btn btn-link btn-sm">Schema</button>
+          <button type="button" id="btn-json-schema" class="btn btn-link btn-sm">JSON Schema</button>
+        </div>
+      </li>
+      <li class="nav-item">
+        <div id="schema" class="d-none">
+          <button type="button" id="btn-schema" class="btn btn-link btn-sm">Schema</button>
         </div>
       </li>
       <li class="nav-item">

--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -12,6 +12,7 @@ limitations under the License.
 <script>
   show("#sample-data");
   show("#json-schema");
+  show("#schema");
 </script>
 
 <% category = @data[:category] %>
@@ -37,9 +38,11 @@ limitations under the License.
     <div class="text-secondary">
       <%= raw description(@data) %>
     </div>
+    <!--
     <div class="mt-1">
       <%= raw class_examples(@data) %>
     </div>
+    -->
   </div>
   <div class="col-md-auto fixed-right mt-2">
     <div class="navbar-expand-md">

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.65.0"
+  @version "2.66.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -180,6 +180,11 @@ function init_schema_buttons() {
   });
 
   $('#btn-json-schema').on('click', function(event) {
+    const url = '/schema' + window.location.pathname + "?profiles=" + get_selected_profiles().toString();
+    window.open(url,'_blank');
+  });
+
+  $('#btn-schema').on('click', function(event) {
     const url = '/api' + window.location.pathname + "?profiles=" + get_selected_profiles().toString();
     window.open(url,'_blank');
   });


### PR DESCRIPTION
1. Disabling older examples linking (currently it links to incorrect paths due to uid changes)
2. Instead adding an option in resources dropdown to examples repo
3. Adding a button to get json-schema for ocsf schemas. Server already had this functionality but it was buried in api documentation, making it more accessible instead.

![Screenshot 2024-01-05 at 10 18 37 AM](https://github.com/ocsf/ocsf-server/assets/89877409/c5763a19-bcf2-4fb4-a907-6802c5798131)
