### PR TITLE
Issue #63. Fix cross reference logic

### DIFF
--- a/lib/schema.ex
+++ b/lib/schema.ex
@@ -114,7 +114,7 @@ defmodule Schema do
 
   @spec data_type?(binary(), binary() | list(binary())) :: boolean()
   def data_type?(type, type), do: true
-  
+
   def data_type?(type, base_type) when is_binary(base_type) do
     types = Map.get(Repo.data_types(), :attributes)
 
@@ -152,6 +152,9 @@ defmodule Schema do
     |> Repo.classes()
     |> apply_profiles(profiles, MapSet.size(profiles))
   end
+
+  @spec all_classes() :: map()
+  def all_classes(), do: Repo.all_classes()
 
   @doc """
     Returns a single event class.
@@ -430,7 +433,7 @@ defmodule Schema do
   # ----------------------------#
 
   def enrich(data, enum_text, observables) do
-  	Schema.Helper.enrich(data, enum_text, observables)
+    Schema.Helper.enrich(data, enum_text, observables)
   end
 
   # -------------------------------#

--- a/lib/schema/profiles.ex
+++ b/lib/schema/profiles.ex
@@ -48,21 +48,21 @@ defmodule Schema.Profiles do
   @doc """
     Checks classes or objects if all profile attributes are defined.
   """
-  def sanity_check(type, maps, profiles) do
+  def sanity_check(group, maps, profiles) do
     profiles =
       Enum.reduce(maps, profiles, fn {name, map}, acc ->
-        check_profiles(type, name, map, map[:profiles], acc)
+        check_profiles(group, name, map, map[:profiles], acc)
       end)
 
     {maps, profiles}
   end
 
   # Checks if all profile attributes are defined in the given attribute set.
-  defp check_profiles(_type, _name, _map, nil, all_profiles) do
+  defp check_profiles(_group, _name, _map, nil, all_profiles) do
     all_profiles
   end
 
-  defp check_profiles(type, name, map, profiles, all_profiles) do
+  defp check_profiles(group, name, map, profiles, all_profiles) do
     Enum.reduce(profiles, all_profiles, fn p, acc ->
       case acc[p] do
         nil ->
@@ -71,7 +71,7 @@ defmodule Schema.Profiles do
 
         profile ->
           check_profile(name, profile, map[:attributes])
-          link = {type, Atom.to_string(name), map[:caption]}
+          link = %{group: group, type: Atom.to_string(name), caption: map[:caption]}
           profile = Map.update(profile, :_links, [link], fn links -> [link | links] end)
           Map.put(acc, p, profile)
       end

--- a/lib/schema/repo.ex
+++ b/lib/schema/repo.ex
@@ -119,6 +119,11 @@ defmodule Schema.Repo do
     Agent.get(__MODULE__, fn schema -> Cache.classes(schema) |> filter(extensions) end)
   end
 
+  @spec all_classes() :: map()
+  def all_classes() do
+    Agent.get(__MODULE__, fn schema -> Cache.all_classes(schema) end)
+  end
+
   @spec export_classes() :: map()
   def export_classes() do
     Agent.get(__MODULE__, fn schema -> Cache.export_classes(schema) end)
@@ -248,8 +253,8 @@ defmodule Schema.Repo do
   defp remove_extension_links(nil, _extensions), do: []
 
   defp remove_extension_links(links, extensions) do
-    Enum.filter(links, fn {_, key, _} ->
-      [ext | rest] = String.split(key, "/")
+    Enum.filter(links, fn link ->
+      [ext | rest] = String.split(link[:type], "/")
       rest == [] or MapSet.member?(extensions, ext)
     end)
   end

--- a/lib/schema_web/controllers/schema_controller.ex
+++ b/lib/schema_web/controllers/schema_controller.ex
@@ -81,7 +81,7 @@ defmodule SchemaWeb.SchemaController do
             category(:string, "Class category", required: true)
             category_name(:string, "Class category caption", required: true)
             profiles(:array, "Class profiles", items: %PhoenixSwagger.Schema{type: :string})
-            uid(:integer, "Class unique indentifier", required: true)
+            uid(:integer, "Class unique identifier", required: true)
           end
 
           example([
@@ -168,32 +168,40 @@ defmodule SchemaWeb.SchemaController do
 
   @spec versions(Plug.Conn.t(), any) :: Plug.Conn.t()
   def versions(conn, _params) do
-
     url = Application.get_env(:schema_server, SchemaWeb.Endpoint)[:url]
 
     # The :url key is meant to be set for production, but isn't set for local development
-    base_url = if url == nil do
-      "#{conn.scheme}://#{conn.host}:#{conn.port}"
-    else
-      "#{conn.scheme}://#{Keyword.fetch!(url, :host)}:#{Keyword.fetch!(url, :port)}"
-    end
+    base_url =
+      if url == nil do
+        "#{conn.scheme}://#{conn.host}:#{conn.port}"
+      else
+        "#{conn.scheme}://#{Keyword.fetch!(url, :host)}:#{Keyword.fetch!(url, :port)}"
+      end
 
-    available_versions = Schemas.versions()
-    |> Enum.map(fn {version, _} -> version end)
+    available_versions =
+      Schemas.versions()
+      |> Enum.map(fn {version, _} -> version end)
 
-    default_version = %{:version => Schema.version(), :url => "#{base_url}/#{Schema.version()}/api"}
+    default_version = %{
+      :version => Schema.version(),
+      :url => "#{base_url}/#{Schema.version()}/api"
+    }
 
-    versions_response = case available_versions do
-      [] ->
-        # If there is no response, we only provide a single schema
-        %{:versions => [default_version], :default => default_version}
+    versions_response =
+      case available_versions do
+        [] ->
+          # If there is no response, we only provide a single schema
+          %{:versions => [default_version], :default => default_version}
 
-      [_head | _tail] ->
-        available_versions_objects = available_versions
-        |> Enum.map(fn version -> %{:version => version, :url => "#{base_url}/#{version}/api"} end)
-        %{:versions => available_versions_objects, :default => default_version}
+        [_head | _tail] ->
+          available_versions_objects =
+            available_versions
+            |> Enum.map(fn version ->
+              %{:version => version, :url => "#{base_url}/#{version}/api"}
+            end)
 
-    end
+          %{:versions => available_versions_objects, :default => default_version}
+      end
 
     send_json_resp(conn, versions_response)
   end
@@ -256,6 +264,7 @@ defmodule SchemaWeb.SchemaController do
       Enum.into(get_profiles(params), %{}, fn {k, v} ->
         {k, Schema.delete_links(v)}
       end)
+
     send_json_resp(conn, profiles)
   end
 
@@ -271,7 +280,7 @@ defmodule SchemaWeb.SchemaController do
   @doc """
   Get a profile by name.
   get /api/profiles/:name
-  get /api/profiles/:extention/:name
+  get /api/profiles/:extension/:name
   """
   swagger_path :profile do
     get("/api/profiles/{name}")
@@ -294,13 +303,15 @@ defmodule SchemaWeb.SchemaController do
 
   @spec profile(Plug.Conn.t(), map) :: Plug.Conn.t()
   def profile(conn, %{"id" => id} = params) do
-    name = case params["extension"] do
-      nil -> id
-      extension -> "#{extension}/#{id}"
-    end
+    name =
+      case params["extension"] do
+        nil -> id
+        extension -> "#{extension}/#{id}"
+      end
 
     try do
       data = Schema.profiles()
+
       case Map.get(data, name) do
         nil ->
           send_json_resp(conn, 404, %{error: "Profile #{name} not found"})
@@ -553,7 +564,7 @@ defmodule SchemaWeb.SchemaController do
   @doc """
   Get an object by name.
   get /api/objects/:name
-  get /api/objects/:extention/:name
+  get /api/objects/:extension/:name
   """
   swagger_path :object do
     get("/api/objects/{name}")
@@ -650,7 +661,7 @@ defmodule SchemaWeb.SchemaController do
   swagger_path :export_schema do
     get("/export/schema")
     summary("Export schema")
-    description("Get OCSF schema defintions, including data types, objects, and classes.")
+    description("Get OCSF schema definitions, including data types, objects, and classes.")
     produces("application/json")
     tag("Schema Export")
 
@@ -900,7 +911,9 @@ defmodule SchemaWeb.SchemaController do
         default: false
       )
 
-      data(:body, PhoenixSwagger.Schema.ref(:Event), "The event data to be enriched.", required: true)
+      data(:body, PhoenixSwagger.Schema.ref(:Event), "The event data to be enriched.",
+        required: true
+      )
     end
 
     response(200, "Success")
@@ -978,7 +991,9 @@ defmodule SchemaWeb.SchemaController do
         allowEmptyValue: true
       )
 
-      data(:body, PhoenixSwagger.Schema.ref(:Event), "The event data to be translated", required: true)
+      data(:body, PhoenixSwagger.Schema.ref(:Event), "The event data to be translated",
+        required: true
+      )
     end
 
     response(200, "Success")
@@ -1026,7 +1041,9 @@ defmodule SchemaWeb.SchemaController do
     tag("Tools")
 
     parameters do
-      data(:body, PhoenixSwagger.Schema.ref(:Event), "The event data to be validated", required: true)
+      data(:body, PhoenixSwagger.Schema.ref(:Event), "The event data to be validated",
+        required: true
+      )
     end
 
     response(200, "Success")
@@ -1082,7 +1099,7 @@ defmodule SchemaWeb.SchemaController do
   @doc """
   Returns randomly generated event sample data for the given name.
   get /sample/classes/:name
-  get /sample/classes/:extention/:name
+  get /sample/classes/:extension/:name
   """
   swagger_path :sample_class do
     get("/sample/classes/{name}")
@@ -1144,7 +1161,7 @@ defmodule SchemaWeb.SchemaController do
   @doc """
   Returns randomly generated object sample data for the given name.
   get /sample/objects/:name
-  get /sample/objects/:extention/:name
+  get /sample/objects/:extension/:name
   """
   swagger_path :sample_object do
     get("/sample/objects/{name}")

--- a/lib/schema_web/templates/layout/app.html.eex
+++ b/lib/schema_web/templates/layout/app.html.eex
@@ -114,7 +114,7 @@ limitations under the License.
   <a class="navbar-brand" href="#">OCSF Schema</a>
 
   <nav class="navbar navbar-bg collapse navbar-collapse navbar-expand-md navbar-light fixed-left">
-    <a href=<%= Routes.static_path(@conn, "/?extensions=") %> onclick="reset_home_page()" class="navbar-brand ocsf-logo">
+    <a href="<%= Routes.static_path(@conn, "/?extensions=") %>" onclick="reset_home_page()" class="navbar-brand ocsf-logo">
       <img src='<%= Routes.static_path(@conn, "/images/ocsf-logo.png") %>' alt="OCSF"/>
     </a>
     <h6 class="container-fluid version">

--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -93,7 +93,7 @@ limitations under the License.
         <% name = Atom.to_string(key) %>
         <tr class="<%= field_classes(field)%>">
           <td class="name"><%= raw format_attribute_caption(name, field) %></td>
-          <td data-toggle="tooltip" title="<%= field[:_source] %>"><%= raw format_attribute_name(name) %></td>
+          <td data-toggle="tooltip" title="<%= format_class_attribute_source(field) %>"><%= raw format_attribute_name(name) %></td>
           <td class="capitalize"><%= field[:group] %></td>
           <td class="capitalize"><%= format_requirement(field) %></td>
           <td class="extensions"><%= raw format_type(@conn, field) %></td>

--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -93,7 +93,7 @@ limitations under the License.
         <% name = Atom.to_string(key) %>
         <tr class="<%= field_classes(field)%>">
           <td class="name"><%= raw format_attribute_caption(name, field) %></td>
-          <td data-toggle="tooltip" title="<%= format_class_attribute_source(field) %>"><%= raw format_attribute_name(name) %></td>
+          <td data-toggle="tooltip" title="<%= format_class_attribute_source(@data[:name], field) %>"><%= raw format_attribute_name(name) %></td>
           <td class="capitalize"><%= field[:group] %></td>
           <td class="capitalize"><%= format_requirement(field) %></td>
           <td class="extensions"><%= raw format_type(@conn, field) %></td>

--- a/lib/schema_web/templates/page/dictionary.html.eex
+++ b/lib/schema_web/templates/page/dictionary.html.eex
@@ -18,12 +18,19 @@ limitations under the License.
     </div>
   </div>
   <div class="col-md-auto fixed-right mt-2">
-    <div class="form-inline">
-      <ul class="navbar-nav">
-        <li class="nav-item">
-          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-        </li>
-      </ul>
+    <div class="navbar-expand-md">
+      <div class="form-inline">
+        <ul class="navbar-nav">
+          <li class="nav-item mr-2">
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
+            <br><small>Expand All and Collapse All are slow &mdash; be patient</small>
+          </li>
+          <li class="nav-item">
+            <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/lib/schema_web/templates/page/dictionary.html.eex
+++ b/lib/schema_web/templates/page/dictionary.html.eex
@@ -46,7 +46,7 @@ limitations under the License.
           <td class="name"><%= raw format_caption(name, field) %></td>
           <td><%= format_attribute_name(name) %></td>
           <td class="extensions"><%= raw format_type(@conn, field) %></td>
-          <td class="extensions"><%= raw links(@conn, key, field[:_links]) %></td>
+          <td class="extensions"><%= raw dictionary_links(@conn, key, field[:_links]) %></td>
           <td><%= raw description(field) %></td>
         </tr>
       <% end %>

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -105,7 +105,7 @@
   <div class="links">
     <h5>Referenced By</h5>
     <div class="extensions">
-      <%= raw links(@conn, @data[:caption], links) %>
+      <%= raw object_links(@conn, @data[:name], links) %>
     </div>
   </div>
 <% end %>

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -102,11 +102,9 @@
 <%= if Enum.empty?(links) do %>
   <div></div>
 <% else %>
-  <div class="links">
-    <h5>Referenced By</h5>
-    <div class="extensions">
-      <%= raw object_links(@conn, @data[:name], links) %>
-    </div>
+  <a class="h5 links dropdown-toggle" data-toggle="collapse" data-target="#object-links" aria-expanded="false" aria-controls="object-links">Referenced By</a>
+  <div class="extensions collapse" id="object-links">
+    <%= raw object_links(@conn, @data[:name], links) %>
   </div>
 <% end %>
 <% constraints = @data[:constraints] %>

--- a/lib/schema_web/templates/page/objects.html.eex
+++ b/lib/schema_web/templates/page/objects.html.eex
@@ -44,7 +44,7 @@ limitations under the License.
         <tr class="ocsf-class" <%= raw format_profiles(map[:profiles])%>>
           <td class="name"><%= raw format_attribute_caption(name, map) %></td>
           <td class="extensions"><a href="<%= path %>"><%= name %></a></td>
-          <td class="extensions"><%= raw links(@conn, name, map[:_links]) %></td>
+          <td class="extensions"><%= raw object_links(@conn, map[:name], map[:_links], :collapse) %></td>
           <td><%= raw description(map) %></td>
         </tr>
       <% end %>

--- a/lib/schema_web/templates/page/objects.html.eex
+++ b/lib/schema_web/templates/page/objects.html.eex
@@ -17,12 +17,18 @@ limitations under the License.
     </div>
   </div>
   <div class="col-md-auto fixed-right mt-2">
-    <div class="form-inline">
-      <ul class="navbar-nav">
-        <li class="nav-item">
-          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-        </li>
-      </ul>
+    <div class="navbar-expand-md">
+      <div class="form-inline">
+        <ul class="navbar-nav">
+          <li class="nav-item mr-2">
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
+          </li>
+          <li class="nav-item">
+            <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/lib/schema_web/templates/page/profile.html.eex
+++ b/lib/schema_web/templates/page/profile.html.eex
@@ -88,11 +88,9 @@
 <%= if Enum.empty?(links) do %>
   <div></div>
 <% else %>
-  <div class="links">
-    <h5>Referenced By</h5>
-    <div>
-      <%= raw profile_links(@conn, @data[:name], links) %>
-    </div>
+  <a class="h5 links dropdown-toggle" data-toggle="collapse" data-target="#profile-links" aria-expanded="false" aria-controls="object-links">Referenced By</a>
+  <div class="extensions collapse" id="profile-links">
+    <%= raw profile_links(@conn, @data[:name], links) %>
   </div>
 <% end %>
 <script>

--- a/lib/schema_web/templates/page/profile.html.eex
+++ b/lib/schema_web/templates/page/profile.html.eex
@@ -91,7 +91,7 @@
   <div class="links">
     <h5>Referenced By</h5>
     <div>
-      <%= raw links(@conn, @data[:caption], links) %>
+      <%= raw profile_links(@conn, @data[:name], links) %>
     </div>
   </div>
 <% end %>

--- a/lib/schema_web/templates/page/profiles.html.eex
+++ b/lib/schema_web/templates/page/profiles.html.eex
@@ -17,12 +17,18 @@ limitations under the License.
     </div>
   </div>
   <div class="col-md-auto fixed-right mt-2">
-    <div class="form-inline">
-      <ul class="navbar-nav">
-        <li class="nav-item">
-          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-        </li>
-      </ul>
+    <div class="navbar-expand-md">
+      <div class="form-inline">
+        <ul class="navbar-nav">
+          <li class="nav-item mr-2">
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
+          </li>
+          <li class="nav-item">
+            <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/lib/schema_web/templates/page/profiles.html.eex
+++ b/lib/schema_web/templates/page/profiles.html.eex
@@ -43,7 +43,7 @@ limitations under the License.
         <tr>
           <td class="name"><a href="<%= path %>"><%= raw format_caption(name, map) %></a></td>
           <td><a href="<%= path %>"><%= name %></a></td>
-          <td><%= raw links(@conn, name, map[:_links]) %></td>
+          <td><%= raw profile_links(@conn, map[:name], map[:_links], :collapse) %></td>
           <td><%= raw map[:description] %></td>
         </tr>
       <% end %>

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -1042,9 +1042,9 @@ defmodule SchemaWeb.PageView do
   defp deprecated(map, deprecated) do
     [
       Map.get(map, :description),
-      "<div class='text-dark mt-2 bg-warning'>DEPRECATED since v",
+      "<div class='text-dark mt-2'><span class='bg-warning'>DEPRECATED since v",
       Map.get(deprecated, :since),
-      "</div>",
+      "</span></div>",
       Map.get(deprecated, :message)
     ]
   end

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -421,20 +421,15 @@ defmodule SchemaWeb.PageView do
     )
   end
 
-  defp collapse_html(collapse_id, button_text, items, primary? \\ true) do
-    style = if primary?, do: "btn-outline-primary", else: "btn-outline-secondary"
-
+  defp collapse_html(collapse_id, text, items) do
     [
-      "<button class=\"btn btn-sm ",
-      style,
-      " dropdown-toggle\" type=\"button\"",
-      " data-toggle=\"collapse\" data-target=\"#",
+      "<a class=\"dropdown-toggle\" data-toggle=\"collapse\" data-target=\"#",
       collapse_id,
       "\" aria-expanded=\"false\" aria-controls=\"",
       collapse_id,
       "\">",
-      button_text,
-      "</button>",
+      text,
+      "</a><br>",
       "<div class=\"collapse\" id=\"",
       collapse_id,
       "\">",
@@ -691,8 +686,7 @@ defmodule SchemaWeb.PageView do
           Integer.to_string(length(html_list)),
           noun_text
         ],
-        Enum.intersperse(html_list, "<br>"),
-        false
+        Enum.intersperse(html_list, "<br>")
       )
     end
   end

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -52,14 +52,15 @@ defmodule SchemaWeb.PageView do
   end
 
   def class_profiles(conn, class, profiles) do
-    case (class[:profiles] || []) do
+    case class[:profiles] || [] do
       [] ->
         ""
+
       list ->
         [
           "<h5 class='mt-3'>Profiles</h5>",
           "Applicable profiles: ",
-          Stream.filter(list, fn profile -> Map.has_key?(profiles, profile)  end)
+          Stream.filter(list, fn profile -> Map.has_key?(profiles, profile) end)
           |> Enum.map_join(", ", fn name ->
             profile_link(conn, get_in(profiles, [name, :caption]), name)
           end),
@@ -251,7 +252,7 @@ defmodule SchemaWeb.PageView do
         end
 
       r ->
-        max_len <> "</br>" <> r
+        max_len <> "<br>" <> r
     end
   end
 
@@ -372,16 +373,16 @@ defmodule SchemaWeb.PageView do
     [
       "At least one attribute must be present: <strong>",
       Enum.join(list, ", "),
-      "</strong><br/>" | acc
+      "</strong><br>" | acc
     ]
   end
 
   def constraints(:just_one, list, acc) do
-    ["Only one attribute can be present: <strong>", Enum.join(list, ", "), "</strong><br/>" | acc]
+    ["Only one attribute can be present: <strong>", Enum.join(list, ", "), "</strong><br>" | acc]
   end
 
   def constraints(name, list, acc) do
-    [Atom.to_string(name), ": <strong>", Enum.join(list, ", "), "</strong><br/>" | acc]
+    [Atom.to_string(name), ": <strong>", Enum.join(list, ", "), "</strong><br>" | acc]
   end
 
   def associations(rules) do
@@ -391,7 +392,7 @@ defmodule SchemaWeb.PageView do
   end
 
   def associations(name, list, acc) do
-    [Atom.to_string(name), ": ", Enum.join(list, ", "), "<br/>" | acc]
+    [Atom.to_string(name), ": ", Enum.join(list, ", "), "<br>" | acc]
   end
 
   def links(_, _, nil), do: ""
@@ -418,12 +419,14 @@ defmodule SchemaWeb.PageView do
     )
   end
 
+  defp join_html([], [], []), do: []
   defp join_html(commons, [], []), do: commons
   defp join_html([], classes, []), do: classes
-  defp join_html(commons, _classes, []), do: commons
-  defp join_html(_, [], objects), do: objects
-  defp join_html([], classes, objects), do: [classes, "<hr/>", objects]
-  defp join_html(commons, _classes, objects), do: [commons, "<hr/>", objects]
+  defp join_html([], [], objects), do: objects
+  defp join_html(commons, classes, []), do: [commons, "<hr>", classes]
+  defp join_html(commons, [], objects), do: [commons, "<hr>", objects]
+  defp join_html([], classes, objects), do: [classes, "<hr>", objects]
+  defp join_html(commons, classes, objects), do: [commons, "<hr>", classes, "<hr>", objects]
 
   defp to_html(_, _, nil), do: []
 
@@ -438,7 +441,7 @@ defmodule SchemaWeb.PageView do
       [],
       fn _, acc ->
         type_path = SchemaWeb.Router.Helpers.static_path(conn, "/base_event")
-        ["<a href='", type_path, "'>", " Base Event</a>", ", " | acc]
+        ["<a href='", type_path, "'>", "Base Event Class</a>", ", " | acc]
       end
     )
     |> List.delete_at(-1)
@@ -455,7 +458,7 @@ defmodule SchemaWeb.PageView do
       [],
       fn {_type, link, name}, acc ->
         type_path = SchemaWeb.Router.Helpers.static_path(conn, "/classes/" <> link)
-        ["<a href='", type_path, "'>", name, " Event</a>", ", " | acc]
+        ["<a href='", type_path, "'>", name, " Class</a>", ", " | acc]
       end
     )
     |> List.delete_at(-1)
@@ -493,11 +496,10 @@ defmodule SchemaWeb.PageView do
   defp deprecated(map, deprecated) do
     [
       Map.get(map, :description),
-      "<div class='text-dark mt-2'><span class='bg-warning'>DEPRECATED since v",
+      "<div class='text-dark mt-2 bg-warning'>DEPRECATED since v",
       Map.get(deprecated, :since),
-      "</span></div>",
+      "</div>",
       Map.get(deprecated, :message)
     ]
   end
-
 end

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -1,4 +1,5 @@
 defmodule SchemaWeb.PageView do
+  alias SchemaWeb.SchemaController
   use SchemaWeb, :view
 
   require Logger
@@ -121,6 +122,22 @@ defmodule SchemaWeb.PageView do
   @spec format_attribute_name(binary()) :: any
   def format_attribute_name(name) do
     Path.basename(name)
+  end
+
+  @spec format_class_attribute_source(map()) :: String.t()
+  def format_class_attribute_source(field) do
+    source = field[:_source]
+    class = Schema.all_classes()[source]
+
+    if class do
+      if class[:hidden?] do
+        "#{class[:caption]} (hidden class)"
+      else
+        class[:caption]
+      end
+    else
+      to_string(source)
+    end
   end
 
   @spec format_range([nil | number | Decimal.t(), ...]) :: nonempty_binary
@@ -395,90 +412,602 @@ defmodule SchemaWeb.PageView do
     [Atom.to_string(name), ": ", Enum.join(list, ", "), "<br>" | acc]
   end
 
-  def links(_, _, nil), do: ""
-  def links(_, _, []), do: ""
+  defp reverse_sort_links(links) do
+    Enum.sort(
+      links,
+      fn link1, link2 ->
+        link1[:group] >= link2[:group] and link1[:caption] >= link2[:caption]
+      end
+    )
+  end
 
-  def links(conn, name, links) do
-    groups =
-      Enum.group_by(
-        links,
-        fn
-          {type, _link, _name} ->
-            type
+  defp collapse_html(collapse_id, button_text, items, primary? \\ true) do
+    style = if primary?, do: "btn-outline-primary", else: "btn-outline-secondary"
 
-          nil ->
-            Logger.warning("group-by: found unused attribute of '#{name}' object")
-            nil
+    [
+      "<button class=\"btn btn-sm ",
+      style,
+      " dropdown-toggle\" type=\"button\"",
+      " data-toggle=\"collapse\" data-target=\"#",
+      collapse_id,
+      "\" aria-expanded=\"false\" aria-controls=\"",
+      collapse_id,
+      "\">",
+      button_text,
+      "</button>",
+      "<div class=\"collapse\" id=\"",
+      collapse_id,
+      "\">",
+      items,
+      "</div>"
+    ]
+  end
+
+  @spec dictionary_links(any(), String.t(), list(Schema.Cache.link_t())) :: <<>> | list()
+  def dictionary_links(_, _, nil), do: ""
+  def dictionary_links(_, _, []), do: ""
+
+  def dictionary_links(conn, attribute_name, links) do
+    groups = Enum.group_by(links, fn link -> link[:group] end)
+
+    commons_html = dictionary_links_common_to_html(conn, groups[:common])
+
+    classes_html =
+      if Enum.empty?(commons_html) do
+        dictionary_links_class_to_html(conn, attribute_name, groups[:class])
+      else
+        Enum.intersperse(
+          [
+            "Referenced by all classes",
+            dictionary_links_class_updated_to_html(conn, attribute_name, groups[:class])
+          ],
+          "<br>"
+        )
+      end
+
+    objects_html = links_object_to_html(conn, attribute_name, groups[:object], :collapse)
+
+    Enum.reject([commons_html, classes_html, objects_html], &Enum.empty?/1)
+    |> Enum.intersperse("<hr>")
+  end
+
+  defp dictionary_links_common_to_html(_, nil), do: []
+
+  defp dictionary_links_common_to_html(conn, linked_classes) do
+    reverse_sort_links(linked_classes)
+    |> Enum.reduce(
+      [],
+      fn _link, acc ->
+        [
+          [
+            "<a href=\"",
+            SchemaWeb.Router.Helpers.static_path(conn, "/base_event"),
+            "\" data-toggle=\"tooltip\ title=\"Directly referenced\">Base Event Class</a>"
+          ]
+          | acc
+        ]
+      end
+    )
+    |> Enum.intersperse("<br>")
+  end
+
+  @spec find_path_to_possible_parent(atom(), atom(), map(), list()) :: {boolean(), list()}
+  defp find_path_to_possible_parent(
+         class,
+         parent_class,
+         all_classes,
+         path_result \\ []
+       ) do
+    cond do
+      class == nil ->
+        {false, []}
+
+      class == parent_class ->
+        {true, [class | path_result]}
+
+      true ->
+        find_path_to_possible_parent(
+          Schema.Utils.to_uid(all_classes[class][:extends]),
+          parent_class,
+          all_classes,
+          [class | path_result]
+        )
+    end
+  end
+
+  defp format_class_path(path, all_classes) do
+    Enum.map(
+      path,
+      fn class ->
+        class_info = all_classes[class]
+
+        if class_info[:hidden?] do
+          [all_classes[class][:caption], " (hidden class)"]
+        else
+          all_classes[class][:caption]
+        end
+      end
+    )
+    |> Enum.intersperse(" ← ")
+  end
+
+  defp dictionary_links_class_to_html(_, _, nil), do: []
+
+  defp dictionary_links_class_to_html(conn, attribute_name, linked_classes) do
+    classes = SchemaController.classes(conn.params())
+    all_classes = Schema.all_classes()
+    attribute_key = Schema.Utils.to_uid(attribute_name)
+
+    html_list =
+      reverse_sort_links(linked_classes)
+      |> Enum.reduce(
+        [],
+        fn link, acc ->
+          type_path = SchemaWeb.Router.Helpers.static_path(conn, "/classes/" <> link[:type])
+          class_key = Schema.Utils.to_uid(link[:type])
+          source = classes[class_key][:attributes][attribute_key][:_source]
+
+          {source_via_hidden?, path} =
+            if all_classes[source][:hidden?] do
+              find_path_to_possible_parent(class_key, source, all_classes)
+            else
+              {false, []}
+            end
+
+          cond do
+            source_via_hidden? ->
+              [
+                [
+                  "<a href=\"",
+                  type_path,
+                  "\" data-toggle=\"tooltip\" title=\"Indirectly referenced via ",
+                  format_class_path(path, all_classes),
+                  "\">",
+                  link[:caption],
+                  " Class</a>"
+                ]
+                | acc
+              ]
+
+            source == nil ->
+              [
+                [
+                  "<a href=\"",
+                  type_path,
+                  "\" data-toggle=\"tooltip\" title=\"No source\">",
+                  link[:caption],
+                  " Class</a> <span class=\"bg-warning\">No source</span>"
+                ]
+                | acc
+              ]
+
+            true ->
+              [
+                [
+                  "<a href=\"",
+                  type_path,
+                  "\" data-toggle=\"tooltip\" title=\"Directly referenced\">",
+                  link[:caption],
+                  " Class</a>"
+                ]
+                | acc
+              ]
+          end
         end
       )
 
-    join_html(
-      to_html(:commons, conn, groups[:common]),
-      to_html(:classes, conn, groups[:class]),
-      to_html(:objects, conn, groups[:object])
-    )
+    if Enum.empty?(html_list) do
+      []
+    else
+      noun_text = if length(html_list) == 1, do: " class", else: " classes"
+
+      collapse_html(
+        ["class-links-", to_string(attribute_name)],
+        ["Referenced by ", Integer.to_string(length(html_list)), noun_text],
+        Enum.intersperse(html_list, "<br>")
+      )
+    end
   end
 
-  defp join_html([], [], []), do: []
-  defp join_html(commons, [], []), do: commons
-  defp join_html([], classes, []), do: classes
-  defp join_html([], [], objects), do: objects
-  defp join_html(commons, classes, []), do: [commons, "<hr>", classes]
-  defp join_html(commons, [], objects), do: [commons, "<hr>", objects]
-  defp join_html([], classes, objects), do: [classes, "<hr>", objects]
-  defp join_html(commons, classes, objects), do: [commons, "<hr>", classes, "<hr>", objects]
+  defp dictionary_links_class_updated_to_html(_, _, nil), do: []
 
-  defp to_html(_, _, nil), do: []
+  defp dictionary_links_class_updated_to_html(conn, attribute_name, linked_classes) do
+    classes = SchemaController.classes(conn.params())
+    all_classes = Schema.all_classes()
+    attribute_key = Schema.Utils.to_uid(attribute_name)
 
-  defp to_html(:commons, conn, classes) do
-    Enum.sort(
-      classes,
-      fn {type1, _, name1}, {type2, _, name2} ->
-        type1 >= type2 and name1 >= name2
-      end
-    )
-    |> Enum.reduce(
-      [],
-      fn _, acc ->
-        type_path = SchemaWeb.Router.Helpers.static_path(conn, "/base_event")
-        ["<a href='", type_path, "'>", "Base Event Class</a>", ", " | acc]
-      end
-    )
-    |> List.delete_at(-1)
+    html_list =
+      reverse_sort_links(linked_classes)
+      |> Enum.reduce(
+        [],
+        fn link, acc ->
+          class_key = Schema.Utils.to_uid(link[:type])
+
+          if class_key == :base_event do
+            acc
+          else
+            type_path = SchemaWeb.Router.Helpers.static_path(conn, "/classes/" <> link[:type])
+            source = classes[class_key][:attributes][attribute_key][:_source]
+
+            cond do
+              source == class_key ->
+                [
+                  [
+                    "<a href=\"",
+                    type_path,
+                    "\" data-toggle=\"tooltip\" title=\"Updated directly\">",
+                    link[:caption],
+                    " Class</a>"
+                  ]
+                  | acc
+                ]
+
+              all_classes[source][:hidden?] ->
+                {ok, path} = find_path_to_possible_parent(class_key, source, all_classes)
+
+                if ok do
+                  [
+                    [
+                      "<a href=\"",
+                      type_path,
+                      "\" data-toggle=\"tooltip\" title=\"Updated indirectly via ",
+                      format_class_path(path, all_classes),
+                      "\">",
+                      link[:caption],
+                      " Class</a>"
+                    ]
+                    | acc
+                  ]
+                else
+                  # This means there's a bad class hierarchy. Show with warning.
+                  [
+                    [
+                      "<a href=\"",
+                      type_path,
+                      "\" data-toggle=\"tooltip\" title=\"Updated via unknown parent\">",
+                      link[:caption],
+                      " Class</a> <span class=\"bg-warning\">Unknown parent</span>"
+                    ]
+                    | acc
+                  ]
+                end
+
+              true ->
+                acc
+            end
+          end
+        end
+      )
+
+    if Enum.empty?(html_list) do
+      []
+    else
+      noun_text = if length(html_list) == 1, do: " class", else: " classes"
+
+      collapse_html(
+        ["class-links-", to_string(attribute_name)],
+        [
+          "Updated in ",
+          Integer.to_string(length(html_list)),
+          noun_text
+        ],
+        Enum.intersperse(html_list, "<br>"),
+        false
+      )
+    end
   end
 
-  defp to_html(:classes, conn, classes) do
-    Enum.sort(
-      classes,
-      fn {type1, _, name1}, {type2, _, name2} ->
-        type1 >= type2 and name1 >= name2
-      end
-    )
-    |> Enum.reduce(
-      [],
-      fn {_type, link, name}, acc ->
-        type_path = SchemaWeb.Router.Helpers.static_path(conn, "/classes/" <> link)
-        ["<a href='", type_path, "'>", name, " Class</a>", ", " | acc]
-      end
-    )
-    |> List.delete_at(-1)
+  # Used by dictionary_links and profile_links
+  defp links_object_to_html(_, _, nil, _), do: []
+
+  defp links_object_to_html(conn, name, linked_objects, list_presentation) do
+    html_list =
+      reverse_sort_links(linked_objects)
+      |> Enum.reduce(
+        [],
+        fn link, acc ->
+          [
+            [
+              "<a href=\"",
+              SchemaWeb.Router.Helpers.static_path(conn, "/objects/" <> link[:type]),
+              "\">",
+              link[:caption],
+              " Object</a>"
+            ]
+            | acc
+          ]
+        end
+      )
+
+    cond do
+      Enum.empty?(html_list) ->
+        []
+
+      list_presentation == :collapse ->
+        noun_text = if length(html_list) == 1, do: " object", else: " objects"
+
+        collapse_html(
+          ["object-links-", to_string(name)],
+          ["Referenced by ", Integer.to_string(length(html_list)), noun_text],
+          Enum.intersperse(html_list, "<br>")
+        )
+
+      true ->
+        Enum.intersperse(html_list, "<br>")
+    end
   end
 
-  defp to_html(:objects, conn, objects) do
-    Enum.sort(
-      objects,
-      fn {type1, _, name1}, {type2, _, name2} ->
-        type1 >= type2 and name1 >= name2
-      end
-    )
+  @spec object_links(any(), String.t(), list(Schema.Cache.link_t()), nil | :collapse) ::
+          <<>> | list()
+  def object_links(conn, name, links, list_presentation \\ nil)
+  def object_links(_, _, nil, _), do: ""
+  def object_links(_, _, [], _), do: ""
+
+  def object_links(conn, name, links, list_presentation) do
+    groups = Enum.group_by(links, fn link -> link[:group] end)
+
+    commons_html = object_links_common_to_html(conn, groups[:common], list_presentation)
+    classes_html = object_links_class_to_html(conn, name, groups[:class], list_presentation)
+    objects_html = object_links_object_to_html(conn, name, groups[:object], list_presentation)
+
+    Enum.reject([commons_html, classes_html, objects_html], &Enum.empty?/1)
+    |> Enum.intersperse("<hr>")
+  end
+
+  defp link_attributes(link) do
+    attribute_keys = link[:attribute_keys]
+    attribute_keys_size = if attribute_keys == nil, do: 0, else: MapSet.size(attribute_keys)
+
+    case attribute_keys_size do
+      0 ->
+        "No attributes"
+
+      1 ->
+        ["Attribute: ", to_string(Enum.at(attribute_keys, 0))]
+
+      _ ->
+        ["Attributes: ", Enum.intersperse(Enum.map(attribute_keys, &to_string/1), ", ")]
+    end
+  end
+
+  defp object_links_common_to_html(_, nil, _), do: []
+
+  defp object_links_common_to_html(conn, linked_classes, list_presentation) do
+    html_list =
+      reverse_sort_links(linked_classes)
+      |> Enum.reduce(
+        [],
+        fn link, acc ->
+          type_path =
+            if link[:type] == "base_event" do
+              SchemaWeb.Router.Helpers.static_path(conn, "/base_event")
+            else
+              SchemaWeb.Router.Helpers.static_path(conn, "/classes/" <> link[:type])
+            end
+
+          [
+            if list_presentation == :collapse do
+              [
+                "<a href=\"",
+                type_path,
+                "\" data-toggle=\"tooltip\" title=\"",
+                link_attributes(link),
+                "\">",
+                link[:caption],
+                " Class</a>"
+              ]
+            else
+              [
+                "<dt><a href=\"",
+                type_path,
+                "\">",
+                link[:caption],
+                " Class</a><dd class=\"ml-3\">",
+                link_attributes(link)
+              ]
+            end
+            | acc
+          ]
+        end
+      )
+
+    cond do
+      Enum.empty?(html_list) ->
+        []
+
+      list_presentation == :collapse ->
+        Enum.intersperse(html_list, "<br>")
+
+      true ->
+        ["<dl class=\"m-0\">", html_list, "</dl>"]
+    end
+  end
+
+  defp object_links_class_to_html(_, _, nil, _), do: []
+
+  defp object_links_class_to_html(conn, name, linked_classes, list_presentation) do
+    html_list =
+      reverse_sort_links(linked_classes)
+      |> Enum.reduce(
+        [],
+        fn link, acc ->
+          type_path = SchemaWeb.Router.Helpers.static_path(conn, "/classes/" <> link[:type])
+
+          [
+            if list_presentation == :collapse do
+              [
+                "<a href=\"",
+                type_path,
+                "\" data-toggle=\"tooltip\" title=\"",
+                link_attributes(link),
+                "\">",
+                link[:caption],
+                " Class</a>"
+              ]
+            else
+              [
+                "<dt><a href=\"",
+                type_path,
+                "\">",
+                link[:caption],
+                " Class</a><dd class=\"ml-3\">",
+                link_attributes(link)
+              ]
+            end
+            | acc
+          ]
+        end
+      )
+
+    cond do
+      Enum.empty?(html_list) ->
+        []
+
+      list_presentation == :collapse ->
+        noun_text = if length(html_list) == 1, do: " class", else: " classes"
+
+        collapse_html(
+          ["class-links-", to_string(name)],
+          ["Referenced by ", Integer.to_string(length(html_list)), noun_text],
+          Enum.intersperse(html_list, "<br>")
+        )
+
+      true ->
+        ["<dl class=\"m-0\">", html_list, "</dl>"]
+    end
+  end
+
+  defp object_links_object_to_html(_, _, nil, _), do: []
+
+  defp object_links_object_to_html(conn, name, linked_objects, list_presentation) do
+    html_list =
+      reverse_sort_links(linked_objects)
+      |> Enum.reduce(
+        [],
+        fn link, acc ->
+          type_path = SchemaWeb.Router.Helpers.static_path(conn, "/objects/" <> link[:type])
+
+          [
+            if list_presentation == :collapse do
+              [
+                "<a href=\"",
+                type_path,
+                "\" data-toggle=\"tooltip\" title=\"",
+                link_attributes(link),
+                "\">",
+                link[:caption],
+                " Object</a>"
+              ]
+            else
+              [
+                "<dt><a href=\"",
+                type_path,
+                "\">",
+                link[:caption],
+                " Object</a><dd class=\"ml-3\">",
+                link_attributes(link)
+              ]
+            end
+            | acc
+          ]
+        end
+      )
+
+    cond do
+      Enum.empty?(html_list) ->
+        []
+
+      list_presentation == :collapse ->
+        noun_text = if length(html_list) == 1, do: " object", else: " objects"
+
+        collapse_html(
+          ["object-links-", to_string(name)],
+          ["Referenced by ", Integer.to_string(length(html_list)), noun_text],
+          Enum.intersperse(html_list, "<br>")
+        )
+
+      true ->
+        ["<dl class=\"m-0\">", html_list, "</dl>"]
+    end
+  end
+
+  @spec profile_links(any(), String.t(), list(Schema.Cache.link_t()), nil | :collapse) ::
+          <<>> | list()
+  def profile_links(conn, profile_name, links, list_presentation \\ nil)
+  def profile_links(_, _, nil, _), do: ""
+  def profile_links(_, _, [], _), do: ""
+
+  def profile_links(conn, profile_name, links, list_presentation) do
+    groups = Enum.group_by(links, fn link -> link[:group] end)
+
+    commons_html = profile_links_common_to_html(conn, groups[:common])
+
+    classes_html =
+      profile_links_class_to_html(conn, profile_name, groups[:class], list_presentation)
+
+    objects_html = links_object_to_html(conn, profile_name, groups[:object], list_presentation)
+
+    Enum.reject([commons_html, classes_html, objects_html], &Enum.empty?/1)
+    |> Enum.intersperse("<hr>")
+  end
+
+  defp profile_links_common_to_html(_, nil), do: []
+
+  defp profile_links_common_to_html(conn, linked_classes) do
+    reverse_sort_links(linked_classes)
     |> Enum.reduce(
       [],
-      fn {_type, link, name}, acc ->
-        type_path = SchemaWeb.Router.Helpers.static_path(conn, "/objects/" <> link)
-        ["<a href='", type_path, "'>", name, " Object</a>", ", " | acc]
+      fn _link, acc ->
+        [
+          [
+            "<a href=\"",
+            SchemaWeb.Router.Helpers.static_path(conn, "/base_event"),
+            "\">Base Event Class</a>"
+          ]
+          | acc
+        ]
       end
     )
-    |> List.delete_at(-1)
+    |> Enum.intersperse("<br>")
+  end
+
+  defp profile_links_class_to_html(_, _, nil, _), do: []
+
+  defp profile_links_class_to_html(conn, profile_name, linked_classes, list_presentation) do
+    html_list =
+      reverse_sort_links(linked_classes)
+      |> Enum.reduce(
+        [],
+        fn link, acc ->
+          [
+            [
+              "<a href=\"",
+              SchemaWeb.Router.Helpers.static_path(conn, "/classes/" <> link[:type]),
+              "\">",
+              link[:caption],
+              " Class</a>"
+            ]
+            | acc
+          ]
+        end
+      )
+
+    cond do
+      Enum.empty?(html_list) ->
+        []
+
+      list_presentation == :collapse ->
+        noun_text = if length(html_list) == 1, do: " class", else: " classes"
+
+        collapse_html(
+          ["class-links-", to_string(profile_name)],
+          ["Referenced by ", Integer.to_string(length(html_list)), noun_text],
+          Enum.intersperse(html_list, "<br>")
+        )
+
+      true ->
+        Enum.intersperse(html_list, "<br>")
+    end
   end
 
   defp format_number(n) do

--- a/lib/schemas.ex
+++ b/lib/schemas.ex
@@ -39,9 +39,9 @@ defmodule Schemas do
   @doc """
   Returns a list of schemas is the given directory.
 
-  Returns {:ok, list} in case of success, {:error, reason} otherwise.
+  Returns list of {version, path} tuples in case of success, {:error, reason} otherwise.
   """
-  @spec ls(Path.t()) :: {:ok, list()} | {:error, File.posix()}
+  @spec ls(Path.t()) :: list({String.t(), String.t()}) | {:error, File.posix()}
   def ls(path) do
     with {:ok, list} <- File.ls(path) do
       Stream.map(list, fn name ->

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.67.0"
+  @version "2.68.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"


### PR DESCRIPTION
Issue #63. Fix cross reference logic. This logic is used the following pages: dictionary, objects, object detail, profiles, and profile detail. Before this, classes were ignored when Base Event was one of the references. This was presumably done because when Base Event is referenced, it implies all other classes are also referenced.

The prior behavior was that when "Base Event" was a reference, no other classes were shown. With this change, the _entire_ list of classes is shown when Base Event is a reference because, of course, anything that is in Base Event is also in every other class. 

**The question is: is this helpful? Is showing _all_ classes helpful when Base Event is the one of the references?**

Perhaps what we want instead is to show which classes or objects add or override an attribute. Let me know.

(The remainder of this description contains relatively minor details.)

The references are the form, with the 3 sections existing when applicable:
```
Base Event Class
-----------------
Foo Class
Bar Class
-----------------
Baz Object
Quux Object
```

Now that Base Event will also appear in the classes section, the naming of event classes now consistently takes the form "Foo Class" instead of "Foo Event". This prevents an awkward "Base Event Event" name. In addition the form "Foo Class" is consistent with the class page, which uses the form "Foo (42) Class" where "Foo" is the class name and "(42)" is the class ID in parenthesis.

Listing "Base Event Class" at the top is redundant, however it does highlight when then Base Event is a reference.