### PR TITLE
Move GitHub ribbon to the right

### DIFF
--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -136,7 +136,7 @@ body {
   }
 
   .github-ribbon {
-    position: absolute;
+    position: fixed;
     width: 150px;
     height: 150px;
     overflow: hidden;
@@ -158,7 +158,7 @@ body {
     background-color: rgb(160, 0, 0);
     right: -40px;
     background-image: linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.5));
-    bottom: 45px;
+    bottom: 60px;
   }
 }
 
@@ -241,6 +241,7 @@ li {
 
 /* Custom page footer */
 .footer {
+  z-index: 2;
   position: fixed;
   bottom: 0;
   width: 100%;

--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -141,7 +141,7 @@ body {
     height: 150px;
     overflow: hidden;
     z-index: 1;
-    left: 0px;
+    right: 0px;
     bottom: 0px;
   }
   .github-ribbon a {
@@ -150,13 +150,13 @@ body {
     overflow: hidden;
     padding: 6px 0px;
     text-align: center;
-    transform: rotate(45deg);
+    transform: rotate(-45deg);
     text-decoration: none;
     color: rgb(255, 255, 255);
     position: inherit;
     box-shadow: rgba(0, 0, 0, 0.5) 0px 2px 3px 0px;
     background-color: rgb(160, 0, 0);
-    left: -40px;
+    right: -40px;
     background-image: linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.5));
     bottom: 45px;
   }


### PR DESCRIPTION
We currently have many extensions and profiles and the ribbon gets  in the way. As it's not possible to scroll the left panel, it's hard to click on an extension.

<img width="200" alt="Screenshot 2024-01-17 at 15 28 31" src="https://github.com/ocsf/ocsf-server/assets/146833112/87c4869a-2246-4295-8b16-2c5434da946f">
