### PR TITLE
Show enums for attributes in the dictionary view

### DIFF
--- a/lib/schema_web/templates/page/dictionary.html.eex
+++ b/lib/schema_web/templates/page/dictionary.html.eex
@@ -54,7 +54,7 @@ limitations under the License.
           <td><%= format_attribute_name(name) %></td>
           <td class="extensions"><%= raw format_type(@conn, field) %></td>
           <td class="extensions"><%= raw dictionary_links(@conn, key, field[:_links]) %></td>
-          <td><%= raw description(field) %></td>
+          <td><%= raw format_desc(field) %></td>
         </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
Issue: https://github.com/ocsf/ocsf-server/issues/74

Using format_desc to display enums for attributes in dictionary. This is the same function used in objects view.
Before - 
![Screenshot 2024-02-29 at 15 24 44](https://github.com/ocsf/ocsf-server/assets/89877409/d642a2b0-9420-44bf-b0a7-b9b5db7059ff)
After -
![Screenshot 2024-02-29 at 15 23 05](https://github.com/ocsf/ocsf-server/assets/89877409/4533007b-e150-48e7-b2e5-7e91b5d4ddfd)
