### PR TITLE
Add support for defining observables in "patch extends"

### DIFF
--- a/lib/schema/utils.ex
+++ b/lib/schema/utils.ex
@@ -348,8 +348,17 @@ defmodule Schema.Utils do
     right
   end
 
+  @spec put_non_nil(map(), any(), any()) :: map()
+  def put_non_nil(map, _key, nil) when is_map(map) do
+    map
+  end
+
+  def put_non_nil(map, key, value) when is_map(map) do
+    Map.put(map, key, value)
+  end
+
   @doc """
-    Filter attributes based on the given profiles.
+  Filter attributes based on the given profiles.
   """
   @spec apply_profiles(Enum.t(), nil | list() | MapSet.t()) :: Enum.t()
   def apply_profiles(attributes, nil) do

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.69.0"
+  @version "2.70.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/test/test_ocsf_schema/dictionary.json
+++ b/test/test_ocsf_schema/dictionary.json
@@ -134,6 +134,11 @@
       "description": "The name of the entity. See specific usage.",
       "type": "string_t"
     },
+    "numeric_value": {
+      "caption": "Numeric Value",
+      "description": "A numeric value.",
+      "type": "float_t"
+    },
     "ob_by_dict_type_1": {
       "caption": "Ob By Dict Type 1",
       "description": "Example 1 of attribute of an observable by dictionary type ob_by_type_t.",
@@ -169,7 +174,7 @@
     },
     "service": {
       "caption": "Service",
-      "description": "A network service.",
+      "description": "A service.",
       "type": "service"
     },
     "source_node": {
@@ -253,6 +258,10 @@
         "description": "An entity's thingy. (From base dictionary attribute type.)",
         "type": "string_t",
         "type_name": "String"
+      },
+      "float_t": {
+        "caption": "Float",
+        "description": "Real floating-point value."
       },
       "integer_t": {
         "caption": "Integer",

--- a/test/test_ocsf_schema/events/alpha.json
+++ b/test/test_ocsf_schema/events/alpha.json
@@ -4,7 +4,7 @@
   "description": "The Alpha example event class.",
   "name": "alpha",
   "extends": "ghost",
-  "uid": 2,
+  "uid": 1,
   "profiles": [],
   "attributes": {
     "alpha": {

--- a/test/test_ocsf_schema/events/beta.json
+++ b/test/test_ocsf_schema/events/beta.json
@@ -4,7 +4,7 @@
   "description": "The Beta example event class.",
   "name": "beta",
   "extends": "ghost",
-  "uid": 3,
+  "uid": 2,
   "profiles": [],
   "attributes": {
     "beta": {

--- a/test/test_ocsf_schema/events/eta.json
+++ b/test/test_ocsf_schema/events/eta.json
@@ -1,0 +1,22 @@
+{
+  "caption": "Eta",
+  "category": "system",
+  "description": "The Eta example event class.",
+  "name": "eta",
+  "extends": "base_event",
+  "uid": 3,
+  "profiles": [],
+  "attributes": {
+    "name": {
+      "description": "The name of this eta.",
+      "requirement": "required",
+      "observable": 104
+    },
+    "service": {
+      "requirement": "recommended"
+    }
+  },
+  "observables": {
+    "service.name": 105
+  }
+}

--- a/test/test_ocsf_schema/events/network.json
+++ b/test/test_ocsf_schema/events/network.json
@@ -4,7 +4,7 @@
   "description": "The Network event represents a network connection.",
   "name": "network",
   "extends": "alpha",
-  "uid": 1,
+  "uid": 4,
   "profiles": [
     "host"
   ],

--- a/test/test_ocsf_schema/extensions/rpg/dictionary.json
+++ b/test/test_ocsf_schema/extensions/rpg/dictionary.json
@@ -33,6 +33,11 @@
       "description": "Current hit points.",
       "type": "hp_t"
     },
+    "kind": {
+      "caption": "Kind",
+      "description": "A kind.",
+      "type": "string_t"
+    },
     "mana": {
       "caption": "Mana",
       "description": "Current mana, a measure of magical reserves.",

--- a/test/test_ocsf_schema/extensions/rpg/events/eta_(patch).json
+++ b/test/test_ocsf_schema/extensions/rpg/events/eta_(patch).json
@@ -1,0 +1,13 @@
+{
+  "extends": "eta",
+  "attributes": {
+    "service": {
+      "requirement": "recommended",
+      "observable": 42103
+    }
+  },
+  "observables": {
+    "name": 42104,
+    "service.name": 42105
+  }
+}

--- a/test/test_ocsf_schema/extensions/rpg/objects/zeta_(patch).json
+++ b/test/test_ocsf_schema/extensions/rpg/objects/zeta_(patch).json
@@ -1,0 +1,20 @@
+{
+  "caption": "RPG Zeta",
+  "description": "Patch extends of Zeta for the RPG extension.",
+  "extends": "zeta",
+  "observable": 42202,
+  "attributes": {
+    "name": {
+      "description": "Patched name.",
+      "observable": 42203
+    },
+    "numeric_value": {
+      "description": "Patched numeric value.",
+      "observable": 42204
+    },
+    "kind": {
+      "requirement": "recommended",
+      "observable": 42205
+    }
+  }
+}

--- a/test/test_ocsf_schema/objects/_zeta_base_(hidden).json
+++ b/test/test_ocsf_schema/objects/_zeta_base_(hidden).json
@@ -1,0 +1,14 @@
+{
+  "caption": "Zeta Base",
+  "description": "A zeta base.",
+  "name": "_zeta_base",
+  "attributes": {
+    "name": {
+      "description": "The zeta base's human-friendly name",
+      "requirement": "recommended"
+    },
+    "numeric_value": {
+      "requirement": "required"
+    }
+  }
+}

--- a/test/test_ocsf_schema/objects/network_node.json
+++ b/test/test_ocsf_schema/objects/network_node.json
@@ -3,7 +3,7 @@
   "description": "The Network Node object represents a computing device on a network. This is simplified view; the actual OCSF Schema uses far more elaborate model.",
   "name": "network_node",
   "extends": "_entity",
-  "observable": 204,
+  "observable": 203,
   "attributes": {
     "ip": {
       "requirement": "required"

--- a/test/test_ocsf_schema/objects/service.json
+++ b/test/test_ocsf_schema/objects/service.json
@@ -1,6 +1,6 @@
 {
   "caption": "Service",
-  "description": "A network service.",
+  "description": "A service.",
   "name": "service",
   "attributes": {
     "name": {

--- a/test/test_ocsf_schema/objects/zeta.json
+++ b/test/test_ocsf_schema/objects/zeta.json
@@ -1,0 +1,15 @@
+{
+  "name": "zeta",
+  "extends": "_zeta_base",
+  "observable": 204,
+  "attributes": {
+    "name": {
+      "description": "The zeta's human-friendly name",
+      "requirement": "recommended"
+    },
+    "numeric_value": {
+      "requirement": "required",
+      "observable": 205
+    }
+  }
+}


### PR DESCRIPTION
Currently observable definitions are flagged with an "unsupported" error for the patch extends case.

A patch extends is triggered when a class or object (most usefully an extension class or object) is defined with an extends property that refers to a class or object in the core schema, and either the name matches the extends or it doesn't have an extends. This patch allows modification of the class or object in the extends property as shown below, and then the patching item disappears (it isn't added to the schema).

A patch currently does these things:
- The profiles in the patching item are merged with the base item.
- The attributes in the patching item are merged with the base item.
- Observable definitions in the patching item cause an error, regardless of kind (top level object observable, attribute observable, or class attribute path observables).

With this issue we want to support merging the observable definitions from the patching item to the base item.

Fixes issue https://github.com/ocsf/ocsf-server/issues/82.

Related to PR https://github.com/ocsf/ocsf-validator/pull/19.