### PR TITLE
Fix JSON Schema link for base_event

### DIFF
--- a/lib/schema_web/controllers/page_controller.ex
+++ b/lib/schema_web/controllers/page_controller.ex
@@ -172,20 +172,11 @@ defmodule SchemaWeb.PageController do
   end
 
   @doc """
-  Renders the base event attributes.
+  Redirects from the older /base_event URL to /classes/base_event.
   """
   @spec base_event(Plug.Conn.t(), any) :: Plug.Conn.t()
-  def base_event(conn, params) do
-    data =
-      Schema.class(:base_event)
-      |> sort_attributes()
-      |> Map.put(:key, :base_event)
-
-    render(conn, "class.html",
-      extensions: Schema.extensions(),
-      profiles: SchemaController.get_profiles(params),
-      data: data
-    )
+  def base_event(conn, _params) do
+    redirect(conn, to: "/classes/base_event")
   end
 
   @doc """

--- a/lib/schema_web/templates/layout/app.html.eex
+++ b/lib/schema_web/templates/layout/app.html.eex
@@ -91,7 +91,7 @@ limitations under the License.
         case '/classes':
           $('#classes_id').addClass("active");
           break;
-        case '/base_event':
+        case '/classes/base_event':
           $('#base_event_id').addClass("active");
           break;
         case '/dictionary':
@@ -187,7 +187,7 @@ limitations under the License.
         <a class="nav-link" href='<%= Routes.static_path(@conn, "/classes") %>'>Classes</a>
       </li>
       <li id="base_event_id" class="nav-item">
-        <a class="nav-link" href='<%= Routes.static_path(@conn, "/base_event") %>'>Base Event</a>
+        <a class="nav-link" href='<%= Routes.static_path(@conn, "/classes/base_event") %>'>Base Event</a>
       </li>
       <li id="dictionary_id" class="nav-item">
         <a class="nav-link" href='<%= Routes.static_path(@conn, "/dictionary") %>'>Dictionary</a>

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -620,7 +620,7 @@ defmodule SchemaWeb.PageView do
         [
           [
             "<a href=\"",
-            SchemaWeb.Router.Helpers.static_path(conn, "/base_event"),
+            SchemaWeb.Router.Helpers.static_path(conn, "/classes/base_event"),
             "\" data-toggle=\"tooltip\ title=\"Directly referenced\">Base Event Class</a>"
           ]
           | acc
@@ -902,7 +902,7 @@ defmodule SchemaWeb.PageView do
         fn link, acc ->
           type_path =
             if link[:type] == "base_event" do
-              SchemaWeb.Router.Helpers.static_path(conn, "/base_event")
+              SchemaWeb.Router.Helpers.static_path(conn, "/classes/base_event")
             else
               SchemaWeb.Router.Helpers.static_path(conn, "/classes/" <> link[:type])
             end
@@ -1083,7 +1083,7 @@ defmodule SchemaWeb.PageView do
         [
           [
             "<a href=\"",
-            SchemaWeb.Router.Helpers.static_path(conn, "/base_event"),
+            SchemaWeb.Router.Helpers.static_path(conn, "/classes/base_event"),
             "\">Base Event Class</a>"
           ]
           | acc

--- a/lib/schemas.ex
+++ b/lib/schemas.ex
@@ -68,6 +68,8 @@ defmodule Schemas do
         {_er, _, _} -> false
       end)
       |> Enum.map(fn {_, version, path} -> {version, path} end)
+      # Simplistic lexical sort of versions - not perfect, but better than random
+      |> Enum.sort(fn {v1, _p1}, {v2, _p2} -> v1 <= v2 end)
     else
       {:error, reason} ->
         err_msg = :file.format_error(reason)

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.70.0"
+  @version "2.70.1"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"


### PR DESCRIPTION
Fix issue #70:  JSON Schema link for base_event. Also add simple lexical sorting of schema version list for version dropdown.