### PR TITLE
Excessive warnings cleanup

### DIFF
--- a/lib/schema/cache.ex
+++ b/lib/schema/cache.ex
@@ -46,8 +46,6 @@ defmodule Schema.Cache do
           attribute_keys: nil | MapSet.t(String.t())
         }
 
-  @ocsf_deprecated :"@deprecated"
-
   @doc """
   Load the schema files and initialize the cache.
   """
@@ -1119,25 +1117,8 @@ defmodule Schema.Cache do
 
   defp final_check(maps, dictionary) do
     Enum.into(maps, %{}, fn {name, map} ->
-      deprecated_type(name, map, Map.get(map, @ocsf_deprecated))
-
       {name, final_check(name, map, dictionary)}
     end)
-  end
-
-  defp deprecated_type(_name, _map, nil) do
-  end
-
-  defp deprecated_type(name, map, deprecated) do
-    type =
-      if Map.has_key?(map, :category) do
-        "class"
-      else
-        "object"
-      end
-
-    message = Map.get(deprecated, :message)
-    Logger.warning("The #{name} #{type} has been deprecated. #{message}")
   end
 
   defp final_check(name, map, dictionary) do
@@ -1146,24 +1127,11 @@ defmodule Schema.Cache do
 
     list =
       Enum.reduce(attributes, [], fn {key, attribute}, acc ->
-        deprecated_warning(name, key, attribute)
         missing_desc_warning(attribute[:description], name, key, dictionary)
         add_datetime(Utils.find_entity(dictionary, map, key), key, attribute, acc)
       end)
 
     update_profiles(list, map, profiles, attributes)
-  end
-
-  defp deprecated_warning(name, key, attribute) do
-    case Map.get(attribute, @ocsf_deprecated) do
-      nil ->
-        :ok
-
-      deprecated ->
-        Logger.warning(
-          "The #{key} attribute in #{name} has been deprecated. #{Map.get(deprecated, :message)}"
-        )
-    end
   end
 
   defp missing_desc_warning(nil, name, key, dictionary) do

--- a/lib/schema/profiles.ex
+++ b/lib/schema/profiles.ex
@@ -70,7 +70,6 @@ defmodule Schema.Profiles do
           acc
 
         profile ->
-          check_profile(name, profile, map[:attributes])
           link = %{group: group, type: Atom.to_string(name), caption: map[:caption]}
           profile = Map.update(profile, :_links, [link], fn links -> [link | links] end)
           Map.put(acc, p, profile)
@@ -78,17 +77,4 @@ defmodule Schema.Profiles do
     end)
   end
 
-  defp check_profile(name, profile, attributes) do
-    Enum.each(profile[:attributes], fn {k, p} ->
-      if Map.has_key?(attributes, k) == false do
-        text = "#{name} uses '#{profile[:name]}' profile, but it does not define '#{k}' attribute"
-
-        if p[:requirement] == "required" do
-          Logger.warning(text)
-        else
-          Logger.info(text)
-        end
-      end
-    end)
-  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.70.1"
+  @version "2.70.2"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"


### PR DESCRIPTION
#### Related Issue: https://github.com/ocsf/ocsf-server/issues/88

#### What's changing?
1. Removing excessive warnings during ocsf server build (deprecated entities, profile checks)