### PR TITLE
Temporarily disabling graph endpoints

### DIFF
--- a/lib/schema_web/controllers/page_controller.ex
+++ b/lib/schema_web/controllers/page_controller.ex
@@ -15,54 +15,57 @@ defmodule SchemaWeb.PageController do
 
   alias SchemaWeb.SchemaController
 
-  @spec guidelines(Plug.Conn.t(), any) :: Plug.Conn.t()
-  def guidelines(conn, params) do
-    render(conn, "guidelines.html",
-      extensions: Schema.extensions(),
-      profiles: SchemaController.get_profiles(params)
-    )
-  end
+  # TODO: guidelines.html is missing (route is also commented out)
+  # @spec guidelines(Plug.Conn.t(), any) :: Plug.Conn.t()
+  # def guidelines(conn, params) do
+  #   render(conn, "guidelines.html",
+  #     extensions: Schema.extensions(),
+  #     profiles: SchemaController.get_profiles(params)
+  #   )
+  # end
 
   @spec class_graph(Plug.Conn.t(), any) :: Plug.Conn.t()
   def class_graph(conn, %{"id" => id} = params) do
-    try do
-      case SchemaWeb.SchemaController.class_ex(id, params) do
-        nil ->
-          send_resp(conn, 404, "Not Found: #{id}")
+    # try do
+    #   case SchemaWeb.SchemaController.class_ex(id, params) do
+    #     nil ->
+    #       send_resp(conn, 404, "Not Found: #{id}")
 
-        class ->
-          data = Schema.Graph.build(class)
+    #     class ->
+    #       data = Schema.Graph.build(class)
 
-          render(conn, "class_graph.html",
-            extensions: Schema.extensions(),
-            profiles: SchemaController.get_profiles(params),
-            data: data
-          )
-      end
-    rescue
-      e -> send_resp(conn, 400, "Bad Request: #{inspect(e)}")
-    end
+    #       render(conn, "class_graph.html",
+    #         extensions: Schema.extensions(),
+    #         profiles: SchemaController.get_profiles(params),
+    #         data: data
+    #       )
+    #   end
+    # rescue
+    #   e -> send_resp(conn, 400, "Bad Request: #{inspect(e)}")
+    # end
+    send_resp(conn, 501, "The graph feature is temporarily disabled and will return soon.")
   end
 
   @spec object_graph(Plug.Conn.t(), any) :: Plug.Conn.t()
   def object_graph(conn, %{"id" => id} = params) do
-    try do
-      case SchemaWeb.SchemaController.object_ex(id, params) do
-        nil ->
-          send_resp(conn, 404, "Not Found: #{id}")
+    # try do
+    #   case SchemaWeb.SchemaController.object_ex(id, params) do
+    #     nil ->
+    #       send_resp(conn, 404, "Not Found: #{id}")
 
-        obj ->
-          data = Schema.Graph.build(obj)
+    #     obj ->
+    #       data = Schema.Graph.build(obj)
 
-          render(conn, "object_graph.html",
-            extensions: Schema.extensions(),
-            profiles: SchemaController.get_profiles(params),
-            data: data
-          )
-      end
-    rescue
-      e -> send_resp(conn, 400, "Bad Request: #{inspect(e)}")
-    end
+    #       render(conn, "object_graph.html",
+    #         extensions: Schema.extensions(),
+    #         profiles: SchemaController.get_profiles(params),
+    #         data: data
+    #       )
+    #   end
+    # rescue
+    #   e -> send_resp(conn, 400, "Bad Request: #{inspect(e)}")
+    # end
+    send_resp(conn, 501, "The graph feature is temporarily disabled and will return soon.")
   end
 
   @doc """

--- a/lib/schema_web/router.ex
+++ b/lib/schema_web/router.ex
@@ -134,7 +134,8 @@ defmodule SchemaWeb.Router do
       info: %{
         title: "The OCSF Schema API",
         description:
-          "The Open Cybersecurity Schema Framework (OCSF) server API allows to access the JSON schema definitions and to validate and translate events.",
+          "The Open Cybersecurity Schema Framework (OCSF) server API allows to access the JSON" <>
+            " schema definitions and to validate and translate events.",
         license: %{
           name: "Apache 2.0",
           url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/lib/schema_web/router.ex
+++ b/lib/schema_web/router.ex
@@ -53,7 +53,8 @@ defmodule SchemaWeb.Router do
     get "/object/graph/:extension/:id", PageController, :object_graph
 
     get "/data_types", PageController, :data_types
-    get "/guidelines", PageController, :guidelines
+    # TODO: guidelines.html is missing (also commented out in PageController)
+    # get "/guidelines", PageController, :guidelines
   end
 
   # Other scopes may use custom stacks.
@@ -132,7 +133,8 @@ defmodule SchemaWeb.Router do
     %{
       info: %{
         title: "The OCSF Schema API",
-        description: "The Open Cybersecurity Schema Framework (OCSF) server API allows to access the JSON schema definitions and to validate and translate events.",
+        description:
+          "The Open Cybersecurity Schema Framework (OCSF) server API allows to access the JSON schema definitions and to validate and translate events.",
         license: %{
           name: "Apache 2.0",
           url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.70.2"
+  @version "2.70.3"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"


### PR DESCRIPTION
Temporarily disabling graph endpoints due to bug that pegs a CPU. This in turn can cause the burstable T3 EC2 instance that the OCSF server runs on to be pulled offline.