### PR TITLE
Fix graph to handle direct and indirect recursion

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,7 +14,7 @@ config :schema_server, SchemaWeb.Endpoint,
 config :logger, :console,
   handle_otp_reports: true,
   handle_sasl_reports: true,
-  format: "$time $metadata[$level] $message\n",
+  format: "$date $time [$level] $metadata $message\n",
   metadata: [:request_id]
 
 # Use Jason for JSON parsing in Phoenix

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -29,8 +29,7 @@ config :schema_server, SchemaWeb.Endpoint,
 
 config :logger, :console,
   level: :debug,
-  format: "[$level] $message\n  $metadata\n",
-  # metadata: [:pid, :mfa, :line]
+  format: "[$level] $metadata $message\n",
   metadata: [:mfa, :line]
 
 # Set a higher stacktrace during development. Avoid configuring such

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,6 +2,6 @@ import Config
 
 # Do not print debug messages in production
 config :logger,
-  level: :info
+  level: :warning
 
 config :phoenix, :serve_endpoints, true

--- a/lib/schema_web/controllers/page_controller.ex
+++ b/lib/schema_web/controllers/page_controller.ex
@@ -15,57 +15,38 @@ defmodule SchemaWeb.PageController do
 
   alias SchemaWeb.SchemaController
 
-  # TODO: guidelines.html is missing (route is also commented out)
-  # @spec guidelines(Plug.Conn.t(), any) :: Plug.Conn.t()
-  # def guidelines(conn, params) do
-  #   render(conn, "guidelines.html",
-  #     extensions: Schema.extensions(),
-  #     profiles: SchemaController.get_profiles(params)
-  #   )
-  # end
-
   @spec class_graph(Plug.Conn.t(), any) :: Plug.Conn.t()
   def class_graph(conn, %{"id" => id} = params) do
-    # try do
-    #   case SchemaWeb.SchemaController.class_ex(id, params) do
-    #     nil ->
-    #       send_resp(conn, 404, "Not Found: #{id}")
+    case SchemaWeb.SchemaController.class_ex(id, params) do
+      nil ->
+        send_resp(conn, 404, "Not Found: #{id}")
 
-    #     class ->
-    #       data = Schema.Graph.build(class)
+      class ->
+        data = Schema.Graph.build(class)
 
-    #       render(conn, "class_graph.html",
-    #         extensions: Schema.extensions(),
-    #         profiles: SchemaController.get_profiles(params),
-    #         data: data
-    #       )
-    #   end
-    # rescue
-    #   e -> send_resp(conn, 400, "Bad Request: #{inspect(e)}")
-    # end
-    send_resp(conn, 501, "The graph feature is temporarily disabled and will return soon.")
+        render(conn, "class_graph.html",
+          extensions: Schema.extensions(),
+          profiles: SchemaController.get_profiles(params),
+          data: data
+        )
+    end
   end
 
   @spec object_graph(Plug.Conn.t(), any) :: Plug.Conn.t()
   def object_graph(conn, %{"id" => id} = params) do
-    # try do
-    #   case SchemaWeb.SchemaController.object_ex(id, params) do
-    #     nil ->
-    #       send_resp(conn, 404, "Not Found: #{id}")
+    case SchemaWeb.SchemaController.object_ex(id, params) do
+      nil ->
+        send_resp(conn, 404, "Not Found: #{id}")
 
-    #     obj ->
-    #       data = Schema.Graph.build(obj)
+      obj ->
+        data = Schema.Graph.build(obj)
 
-    #       render(conn, "object_graph.html",
-    #         extensions: Schema.extensions(),
-    #         profiles: SchemaController.get_profiles(params),
-    #         data: data
-    #       )
-    #   end
-    # rescue
-    #   e -> send_resp(conn, 400, "Bad Request: #{inspect(e)}")
-    # end
-    send_resp(conn, 501, "The graph feature is temporarily disabled and will return soon.")
+        render(conn, "object_graph.html",
+          extensions: Schema.extensions(),
+          profiles: SchemaController.get_profiles(params),
+          data: data
+        )
+    end
   end
 
   @doc """
@@ -93,22 +74,18 @@ defmodule SchemaWeb.PageController do
         extension -> "#{extension}/#{id}"
       end
 
-    try do
-      data = SchemaController.get_profiles(params)
+    data = SchemaController.get_profiles(params)
 
-      case Map.get(data, name) do
-        nil ->
-          send_resp(conn, 404, "Not Found: #{name}")
+    case Map.get(data, name) do
+      nil ->
+        send_resp(conn, 404, "Not Found: #{name}")
 
-        profile ->
-          render(conn, "profile.html",
-            extensions: Schema.extensions(),
-            profiles: data,
-            data: sort_attributes(profile)
-          )
-      end
-    rescue
-      e -> send_resp(conn, 400, "Bad Request: #{inspect(e)}")
+      profile ->
+        render(conn, "profile.html",
+          extensions: Schema.extensions(),
+          profiles: data,
+          data: sort_attributes(profile)
+        )
     end
   end
 
@@ -127,22 +104,18 @@ defmodule SchemaWeb.PageController do
   """
   @spec categories(Plug.Conn.t(), map) :: Plug.Conn.t()
   def categories(conn, %{"id" => id} = params) do
-    try do
-      case SchemaController.category_classes(params) do
-        nil ->
-          send_resp(conn, 404, "Not Found: #{id}")
+    case SchemaController.category_classes(params) do
+      nil ->
+        send_resp(conn, 404, "Not Found: #{id}")
 
-        data ->
-          classes = sort_by(data[:classes], :uid)
+      data ->
+        classes = sort_by(data[:classes], :uid)
 
-          render(conn, "category.html",
-            extensions: Schema.extensions(),
-            profiles: SchemaController.get_profiles(params),
-            data: Map.put(data, :classes, classes)
-          )
-      end
-    rescue
-      e -> send_resp(conn, 400, "Bad Request: #{inspect(e)}")
+        render(conn, "category.html",
+          extensions: Schema.extensions(),
+          profiles: SchemaController.get_profiles(params),
+          data: Map.put(data, :classes, classes)
+        )
     end
   end
 
@@ -189,25 +162,21 @@ defmodule SchemaWeb.PageController do
   def classes(conn, %{"id" => id} = params) do
     extension = params["extension"]
 
-    try do
-      case Schema.class(extension, id) do
-        nil ->
-          send_resp(conn, 404, "Not Found: #{id}")
+    case Schema.class(extension, id) do
+      nil ->
+        send_resp(conn, 404, "Not Found: #{id}")
 
-        data ->
-          data =
-            data
-            |> sort_attributes()
-            |> Map.put(:key, Schema.Utils.to_uid(extension, id))
+      data ->
+        data =
+          data
+          |> sort_attributes()
+          |> Map.put(:key, Schema.Utils.to_uid(extension, id))
 
-          render(conn, "class.html",
-            extensions: Schema.extensions(),
-            profiles: SchemaController.get_profiles(params),
-            data: data
-          )
-      end
-    rescue
-      e -> send_resp(conn, 400, "Bad Request: #{inspect(e)}")
+        render(conn, "class.html",
+          extensions: Schema.extensions(),
+          profiles: SchemaController.get_profiles(params),
+          data: data
+        )
     end
   end
 
@@ -226,25 +195,21 @@ defmodule SchemaWeb.PageController do
   """
   @spec objects(Plug.Conn.t(), map) :: Plug.Conn.t()
   def objects(conn, %{"id" => id} = params) do
-    try do
-      case SchemaController.object(params) do
-        nil ->
-          send_resp(conn, 404, "Not Found: #{id}")
+    case SchemaController.object(params) do
+      nil ->
+        send_resp(conn, 404, "Not Found: #{id}")
 
-        data ->
-          data =
-            data
-            |> sort_attributes()
-            |> Map.put(:key, Schema.Utils.to_uid(params["extension"], id))
+      data ->
+        data =
+          data
+          |> sort_attributes()
+          |> Map.put(:key, Schema.Utils.to_uid(params["extension"], id))
 
-          render(conn, "object.html",
-            extensions: Schema.extensions(),
-            profiles: SchemaController.get_profiles(params),
-            data: data
-          )
-      end
-    rescue
-      e -> send_resp(conn, 400, "Bad Request: #{inspect(e)}")
+        render(conn, "object.html",
+          extensions: Schema.extensions(),
+          profiles: SchemaController.get_profiles(params),
+          data: data
+        )
     end
   end
 

--- a/lib/schema_web/router.ex
+++ b/lib/schema_web/router.ex
@@ -53,8 +53,6 @@ defmodule SchemaWeb.Router do
     get "/object/graph/:extension/:id", PageController, :object_graph
 
     get "/data_types", PageController, :data_types
-    # TODO: guidelines.html is missing (also commented out in PageController)
-    # get "/guidelines", PageController, :guidelines
   end
 
   # Other scopes may use custom stacks.

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.70.3"
+  @version "2.70.4"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"


### PR DESCRIPTION
- Re-enable graph feature with fixes to handle indirectly recursive definitions, eliminating infinite loops. 
- Remove try/rescue usage in page_controller as it returns internal implementation details, which is a security risk. Instead letting the Phoenix framework (appropriately) return a generic Internal Server Error. 
- Remove /guidelines route and handling as the related guidelines.html doesn't exist.
- Change prod log level to warning. Improve log format.