### PR TITLE
Sort list of required attributes in JSON schema

### DIFF
--- a/lib/schema/json_schema.ex
+++ b/lib/schema/json_schema.ex
@@ -111,7 +111,7 @@ defmodule Schema.JsonSchema do
   end
 
   defp put_required(map, required) do
-    Map.put(map, "required", required)
+    Map.put(map, "required", Enum.sort(required))
   end
 
   defp encode_objects(schema, nil) do


### PR DESCRIPTION
We are fetching the JSON schema from OCSF server and committing it to a repo. The order of the required fields changes randomly, generating  unnecessarily large diffs.