### PR TITLE
Fix multiple object redefinitions in extensions

### DIFF
--- a/lib/schema/cache.ex
+++ b/lib/schema/cache.ex
@@ -978,7 +978,9 @@ defmodule Schema.Cache do
 
         Logger.info("#{key} #{kind} is patching #{base_key}")
 
-        case Map.get(items, base_key) do
+        # First check the accumulator in case the same object is extended by multiple extensions,
+        # that way the previous modifications are taken into account
+        case Map.get(acc, base_key, Map.get(items, base_key)) do
           nil ->
             Logger.error("#{key} #{kind} attempted to patch invalid item: #{base_key}")
             System.stop(1)

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -146,7 +146,7 @@ defmodule SchemaWeb.PageView do
       end
 
     cond do
-      observable_type_id_map == nil ->
+      observable_type_id_map in [nil, {nil, nil}] ->
         {nil, nil}
 
       Map.has_key?(entity, :observable) ->

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -142,11 +142,11 @@ defmodule SchemaWeb.PageView do
       if observable_object do
         observable_object[:attributes][:type_id][:enum]
       else
-        {nil, nil}
+        nil
       end
 
     cond do
-      observable_type_id_map in [nil, {nil, nil}] ->
+      observable_type_id_map == nil ->
         {nil, nil}
 
       Map.has_key?(entity, :observable) ->


### PR DESCRIPTION
Currently if multiple extensions redefine the same object by adding attributes, only the modifications from the last extension to be loaded will actually be taken into account. 
As an example, the core schema extends the `process` object for the linux extension. If someone was to also extend `process` in the windows extension by adding for instance a `test` attribute (by including a profile or just adding the attribute), this `test` attribute would not show in any of the APIs nor be visible through the frontend.

With the proposed fix, in the case where multiple extensions extend the same object and add the same attribute, only the last loaded extension will be taken into account which seems fine since in this case it is the schema that is poorly defined and not something the ocsf-server could really handle more gracefully.

I also included a fix for the cases where the `observable_type_id_map` is non-existent, if it makes more sense to put it in a dedicated pull request I can move it.