### PR TITLE
Bug fixes

### DIFF
--- a/lib/schema/generator.ex
+++ b/lib/schema/generator.ex
@@ -473,7 +473,7 @@ defmodule Schema.Generator do
   end
 
   defp generate_data(_name, "timestamp_t", _field),
-    do: DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+    do: DateTime.utc_now() |> DateTime.to_unix(:millisecond)
 
   defp generate_data(_name, "datetime_t", _field),
     do: DateTime.utc_now() |> DateTime.to_iso8601()

--- a/lib/schema/json_schema.ex
+++ b/lib/schema/json_schema.ex
@@ -44,12 +44,13 @@ defmodule Schema.JsonSchema do
     else
       class_schema(make_class_ref(name, ext))
     end
-    |> empty_object(properties)
     |> Map.put("title", type[:caption])
     |> Map.put("type", "object")
     |> Map.put("properties", properties)
+    |> Map.put("additionalProperties", false)
     |> put_required(required)
     |> encode_objects(type[:objects])
+    |> empty_object(properties)
   end
 
   defp add_java_class(obj, name) do
@@ -78,7 +79,8 @@ defmodule Schema.JsonSchema do
   defp class_schema(id) do
     %{
       "$schema" => @schema_version,
-      "$id" => id
+      "$id" => id,
+      "additionalProperties" => false
     }
   end
 
@@ -185,7 +187,7 @@ defmodule Schema.JsonSchema do
       true -> type
     end
   end
-  
+
   defp encode_object(schema, _name, attr) do
     type = attr[:object_type]
     Map.put(schema, "$ref", make_object_ref(type))

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.73.1"
+  @version "2.74.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"


### PR DESCRIPTION
Issues Addressed:

1. https://github.com/ocsf/ocsf-server/issues/110
    - Updating the timestamp precision used in sample data generation to millisecs, originally microsec was used which is inconsistent with OCSF's definition of the field.
2. https://github.com/ocsf/ocsf-server/issues/109 (Partially)
    - Adding the missing `additionalProperties` flag to the JSON schema