### PR TITLE
JSON Schema requirement fixes

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.75.0"
+  @version "2.76.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"


### PR DESCRIPTION
The current JSON schema, doesn't add requirements for nested objects. This PR, adds a function to add a `required` key for the nested object definitions in the schema.