### PR TITLE
Issue #139 Show/hide deprecated things everywhere consistently

### DIFF
--- a/lib/schema/cache.ex
+++ b/lib/schema/cache.ex
@@ -1368,6 +1368,7 @@ defmodule Schema.Cache do
     |> copy_new(from, :source)
     |> copy_new(from, :references)
     |> copy_new(from, :sibling)
+    |> copy_new(from, :"@deprecated")
   end
 
   defp copy_new(to, from, key) do

--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -55,37 +55,38 @@ limitations under the License.
   </div>
   <div class="col-md-auto fixed-right mt-2">
     <div class="navbar-expand-md">
-      <div class="form-inline">
-        <ul class="navbar-nav">
-          <li class="nav-item mr-2">
-            <select multiple
-              id="attributes-select"
-              class="selectpicker"
-              data-style="btn-outline-secondary"
-              data-selected-text-format="count > 3"
-              data-actions-box="true"
-              data-width="auto">
-              <option selected id="base-event-select" class="base-event" value="base-event" title="Base Event">Base
-                Event Attributes
-              </option>
-              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
-              <optgroup id="groups-select" label="Groups">
-                <option selected value="classification">Classification</option>
-                <option selected value="context">Context</option>
-                <option selected value="occurrence">Occurrence</option>
-                <option selected value="primary">Primary</option>
-              </optgroup>
-              <optgroup id="requirements-select" label="Requirements">
-                <option class="optional" value="optional" title="Optional">Optional Attributes</option>
-                <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
-              </optgroup>
-            </select>
-          </li>
-          <li class="nav-item">
-            <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-          </li>
-        </ul>
-      </div>
+      <ul class="navbar-nav">
+        <li class="nav-item mr-2">
+          <select multiple
+            id="attributes-select"
+            class="selectpicker"
+            data-style="btn-outline-secondary"
+            data-selected-text-format="count > 3"
+            data-actions-box="true"
+            data-width="auto">
+            <option selected id="base-event-select" class="base-event" value="base-event" title="Base Event">Base
+              Event Attributes
+            </option>
+            <optgroup id="groups-select" label="Groups">
+              <option selected value="classification">Classification</option>
+              <option selected value="context">Context</option>
+              <option selected value="occurrence">Occurrence</option>
+              <option selected value="primary">Primary</option>
+            </optgroup>
+            <optgroup id="requirements-select" label="Requirements">
+              <option class="optional" value="optional" title="Optional">Optional Attributes</option>
+              <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
+            </optgroup>
+          </select>
+        </li>
+        <li class="nav-item">
+          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+          <div class="mt-1">
+            <input type="checkbox" id="show-deprecated" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
+            <label for="show-deprecated">Show deprecated</label>
+          </div>
+        </li>
+      </ul>
     </div>
   </div>
 </div>
@@ -103,14 +104,14 @@ limitations under the License.
     </tr>
     </thead>
     <tbody class="searchable">
-      <%= for {key, field} <- @data[:attributes] do %>
-        <tr class="<%= field_classes(field) %>">
-          <td class="name" data-toggle="tooltip" title="<%= format_class_attribute_source(@data[:key], field) %>"><%= format_attribute_name(key) %></td>
-          <td><%= raw format_attribute_caption(@conn, key, field) %></td>
-          <td class="capitalize"><%= field[:group] %></td>
-          <td><%= raw format_requirement(constraints, key, field) %></td>
-          <td class="extensions"><%= raw format_type(@conn, field) %></td>
-          <td><%= raw format_attribute_desc(key, field) %></td>
+      <%= for {attribute_key, attribute} <- @data[:attributes] do %>
+        <tr class="<%= field_classes(attribute) %>">
+          <td class="name" data-toggle="tooltip" title="<%= format_class_attribute_source(@data[:attribute_key], attribute) %>"><%= format_attribute_name(attribute_key) %></td>
+          <td><%= raw format_attribute_caption(@conn, attribute_key, attribute) %></td>
+          <td class="capitalize"><%= attribute[:group] %></td>
+          <td><%= raw format_requirement(constraints, attribute_key, attribute) %></td>
+          <td class="extensions"><%= raw format_type(@conn, attribute) %></td>
+          <td><%= raw format_attribute_desc(attribute_key, attribute) %></td>
         </tr>
       <% end %>
     </tbody>
@@ -159,4 +160,5 @@ limitations under the License.
 <script>
   init_schema_buttons();
   init_class_profiles();
+  init_show_deprecated();
 </script>

--- a/lib/schema_web/templates/page/class_graph.html.eex
+++ b/lib/schema_web/templates/page/class_graph.html.eex
@@ -31,38 +31,6 @@ limitations under the License.
       <%= raw class[:description] %>
     </div>
   </div>
-  <div class="col-md-auto fixed-right mt-2">
-    <div class="navbar-expand-md">
-      <div class="form-inline">
-        <ul class="navbar-nav">
-          <li class="nav-item mr-2">
-            <select multiple
-              id="attributes-select"
-              class="selectpicker"
-              data-style="btn-outline-secondary"
-              data-selected-text-format="count > 3"
-              data-actions-box="true"
-              data-width="auto">
-              <option selected id="base-event-select" class="base-event" value="base-event" title="Base Event">Base
-                Event Attributes
-              </option>
-              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
-              <optgroup id="groups-select" label="Groups">
-                <option selected value="classification">Classification</option>
-                <option selected value="context">Context</option>
-                <option selected value="occurrence">Occurrence</option>
-                <option selected value="primary">Primary</option>
-              </optgroup>
-              <optgroup id="requirements-select" label="Requirements">
-                <option class="optional" value="optional" title="Optional">Optional Attributes</option>
-                <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
-              </optgroup>
-            </select>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
 </div>
 
 <div id="network"></div>

--- a/lib/schema_web/templates/page/classes.html.eex
+++ b/lib/schema_web/templates/page/classes.html.eex
@@ -16,19 +16,17 @@ limitations under the License.
       The OCSF event classes.
     </div>
   </div>
-  <div class="col-md-auto fixed-right mt-2">
-    <div class="form-inline">
-      <ul class="navbar-nav">
-        <li class="nav-item">
-          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-        </li>
-      </ul>
+  <div class="navbar-nav col-md-auto fixed-right mt-2">
+    <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+    <div class="mt-1">
+      <input type="checkbox" id="show-deprecated" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
+      <label for="show-deprecated">Show deprecated</label>
     </div>
   </div>
 </div>
 
 <div class="mt-4">
-  <table class="table table-striped table-bordered sortable">
+  <table class="table table-bordered sortable">
     <thead>
       <tr class="thead-color">
         <th style="width: 20%">Name</th>
@@ -38,24 +36,26 @@ limitations under the License.
       </tr>
     </thead>
     <tbody class="searchable">
-      <%= for {key, map} <- @data do %>
-        <% name = Atom.to_string(key) %>
-        <% path = Routes.static_path(@conn, "/classes/" <> name) %>
-        <tr class="ocsf-class" <%= raw format_profiles(map[:profiles])%>>
-          <td class="name"><a href="<%= path %>"><%= name %></a></td>
-          <td><%= raw format_caption(name, map) %></td>
-          <% uid = map[:uid] %>
+      <%= for {class_key, class} <- @data do %>
+        <% class_key_str = Atom.to_string(class_key) %>
+        <% class_path = Routes.static_path(@conn, "/classes/" <> class_key_str) %>
+        <tr class="<%= show_deprecated_css_classes(class, "ocsf-class") %>" <%= raw format_profiles(class[:profiles])%>>
+          <td class="name"><a href="<%= class_path %>"><%= class_key_str %></a></td>
+          <td><%= raw format_caption(class_key_str, class) %></td>
+          <% uid = class[:uid] %>
           <%= if uid != nil do %>
             <td><%= uid %></td>
           <% else %>
             <td></td>
           <% end %>
-          <td><%= raw description(map) %></td>
+          <td><%= raw description(class) %></td>
         </tr>
       <% end %>
     </tbody>
   </table>
 </div>
+
 <script>
   init_class_profiles();
+  init_show_deprecated();
 </script>

--- a/lib/schema_web/templates/page/dictionary.html.eex
+++ b/lib/schema_web/templates/page/dictionary.html.eex
@@ -23,24 +23,26 @@ limitations under the License.
   </div>
   <div class="col-md-auto fixed-right mt-2">
     <div class="navbar-expand-md">
-      <div class="form-inline">
-        <ul class="navbar-nav">
-          <li class="nav-item mr-2">
-            <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
-            <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
-            <br><small>Expand All and Collapse All are slow &mdash; be patient</small>
-          </li>
-          <li class="nav-item">
-            <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-          </li>
-        </ul>
-      </div>
+      <ul class="navbar-nav">
+        <li class="nav-item mr-2">
+          <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
+          <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
+          <br><small>Expand All and Collapse All are slow &mdash; be patient</small>
+        </li>
+        <li class="nav-item">
+          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+          <div class="mt-1">
+            <input type="checkbox" id="show-deprecated" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
+            <label for="show-deprecated">Show deprecated</label>
+          </div>
+        </li>
+      </ul>
     </div>
   </div>
 </div>
 
 <div class="mt-4">
-  <table class="table table-striped table-bordered sortable">
+  <table class="table table-bordered sortable">
     <thead>
       <tr class="thead-color">
         <th style="width: 15%">Name</th>
@@ -51,18 +53,20 @@ limitations under the License.
       </tr>
     </thead>
     <tbody class="searchable">
-      <%= for {key, field} <- @data[:attributes] do %>
-        <tr>
-          <td class="name"><%= format_attribute_name(key) %></td>
-          <td><%= raw format_attribute_caption(@conn, key, field) %></td>
-          <td class="extensions"><%= raw format_type(@conn, field) %></td>
-          <td class="extensions"><%= raw dictionary_links(@conn, key, field[:_links]) %></td>
-          <td><%= raw format_dictionary_attribute_desc(key, field) %></td>
+      <%= for {attribute_key, attribute} <- @data[:attributes] do %>
+        <tr class="<%= show_deprecated_css_classes(attribute) %>">
+          <td class="name"><%= format_attribute_name(attribute_key) %></td>
+          <td><%= raw format_attribute_caption(@conn, attribute_key, attribute) %></td>
+          <td class="extensions"><%= raw format_type(@conn, attribute) %></td>
+          <td class="extensions"><%= raw dictionary_links(@conn, attribute_key, attribute[:_links]) %></td>
+          <td><%= raw format_dictionary_attribute_desc(attribute_key, attribute) %></td>
         </tr>
       <% end %>
     </tbody>
   </table>
 </div>
+
 <script>
   init_class_profiles();
+  init_show_deprecated();
 </script>

--- a/lib/schema_web/templates/page/index.html.eex
+++ b/lib/schema_web/templates/page/index.html.eex
@@ -19,31 +19,25 @@ limitations under the License.
       <%= raw @data[:description] %>
     </div>
   </div>
-  <div class="col-md-auto fixed-right mt-2">
-    <div class="navbar-expand-md form-inline">
-      <ul class="navbar-nav">
-        <li class="nav-item mr-2 form-check">
-          <input class="form-check-input" type="checkbox" id="show-deprecated" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
-          <label class="form-check-label" for="show-deprecated">Show deprecated classes</label>
-        </li>
-        <li class="nav-item">
-          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-        </li>
-      </ul>
+  <div class="navbar-nav col-md-auto fixed-right mt-2">
+    <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+    <div class="mt-1">
+      <input type="checkbox" id="show-deprecated" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
+      <label for="show-deprecated">Show deprecated</label>
     </div>
   </div>
 </div>
 
-<div class="mt-4 multi-col">
+<div class="mt-3 multi-col">
   <%= for {category_key, category} <- @data[:attributes] do %>
-  <% category_name = Atom.to_string(category_key) %>
-  <% category_path = Routes.static_path(@conn, "/categories/" <> category_name) %>
+  <% category_key_str = Atom.to_string(category_key) %>
+  <% category_path = Routes.static_path(@conn, "/categories/" <> category_key_str) %>
   <section class="category">
-    <header><a href="<%= category_path %>"><%= raw format_caption(category_name, category) %></a></header>
+    <header><a href="<%= category_path %>"><%= raw format_caption(category_key_str, category) %></a></header>
     <%= for {class_key, class} <- category[:classes] do %>
-    <% class_name = Atom.to_string(class_key) %>
-    <% class_path = Routes.static_path(@conn, "/classes/" <> class_name) %>
-    <div class="<%= show_deprecated_css_classes(class, "ocsf-class") %>" <%= raw format_profiles(class[:profiles])%>><%= raw format_linked_class_caption(class_path, class_name, class) %></div>
+    <% class_key_str = Atom.to_string(class_key) %>
+    <% class_path = Routes.static_path(@conn, "/classes/" <> class_key_str) %>
+    <div class="<%= show_deprecated_css_classes(class, "ocsf-class") %>" <%= raw format_profiles(class[:profiles])%>><%= raw format_linked_class_caption(class_path, class_key_str, class) %></div>
     <% end %>
   </section>
   <% end %>

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -113,7 +113,7 @@
   <div></div>
 <% else %>
   <a class="h5 links dropdown-toggle" data-toggle="collapse" data-target="#object-links" aria-expanded="false" aria-controls="object-links">Referenced By</a>
-  <div class="extensions collapse" id="object-links">
+  <div class="references extensions collapse" id="object-links">
     <%= raw object_links(@conn, @data[:name], links) %>
   </div>
 <% end %>

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -56,28 +56,29 @@
   </div>
   <div class="col-md-auto fixed-right mt-2">
     <div class="navbar-expand-md">
-      <div class="form-inline">
-        <ul class="navbar-nav">
-          <li class="nav-item mr-2">
-            <select multiple
-              id="attributes-select"
-              class="selectpicker"
-              data-style="btn-outline-secondary"
-              data-selected-text-format="count > 3"
-              data-actions-box="true"
-              data-width="auto">
-              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
-              <optgroup id="requirements-select" label="Requirements">
-                <option class="optional" value="optional" title="Optional">Optional Attributes</option>
-                <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
-              </optgroup>
-            </select>
-          </li>
-          <li class="nav-item">
-            <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-          </li>
-        </ul>
-      </div>
+      <ul class="navbar-nav">
+        <li class="nav-item mr-2">
+          <select multiple
+            id="attributes-select"
+            class="selectpicker"
+            data-style="btn-outline-secondary"
+            data-selected-text-format="count > 3"
+            data-actions-box="true"
+            data-width="auto">
+            <optgroup id="requirements-select" label="Requirements">
+              <option class="optional" value="optional" title="Optional">Optional Attributes</option>
+              <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
+            </optgroup>
+          </select>
+        </li>
+        <li class="nav-item">
+          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+          <div class="mt-1">
+            <input type="checkbox" id="show-deprecated" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
+            <label for="show-deprecated">Show deprecated</label>
+          </div>
+        </li>
+      </ul>
     </div>
   </div>
 </div>
@@ -94,13 +95,13 @@
       </tr>
     </thead>
     <tbody class="searchable">
-      <%= for {key, field} <- @data[:attributes] do %>
-      <tr class="<%= field_classes(field)%>">
-        <td class="name" data-toggle="tooltip" title="<%= format_object_attribute_source(@data[:key], field) %>"><%= format_attribute_name(key) %></td>
-        <td><%= raw format_attribute_caption(@conn, key, field) %></td>
-        <td><%= raw format_requirement(constraints, key, field) %></td>
-        <td class="extensions"><%= raw format_type(@conn, field) %></td>
-        <td><%= raw format_attribute_desc(key, field) %></td>
+      <%= for {attribute_key, attribute} <- @data[:attributes] do %>
+      <tr class="<%= field_classes(attribute)%>">
+        <td class="name" data-toggle="tooltip" title="<%= format_object_attribute_source(@data[:attribute_key], attribute) %>"><%= format_attribute_name(attribute_key) %></td>
+        <td><%= raw format_attribute_caption(@conn, attribute_key, attribute) %></td>
+        <td><%= raw format_requirement(constraints, attribute_key, attribute) %></td>
+        <td class="extensions"><%= raw format_type(@conn, attribute) %></td>
+        <td><%= raw format_attribute_desc(attribute_key, attribute) %></td>
       </tr>
       <% end %>
     </tbody>
@@ -125,7 +126,9 @@
 <div class="extensions">
   <%= raw class_profiles(@conn, @data, @profiles) %>
 <div>
+
 <script>
   init_schema_buttons();
   init_class_profiles();
+  init_show_deprecated();
 </script>

--- a/lib/schema_web/templates/page/object_graph.html.eex
+++ b/lib/schema_web/templates/page/object_graph.html.eex
@@ -29,30 +29,6 @@ limitations under the License.
       <%= raw class[:description] %>
     </div>
   </div>
-  <div class="col-md-1"></div>
-  <div class="col-md-auto fixed-right">
-    <nav class="navbar navbar-expand-md navbar-light">
-      <div class="form-inline">
-        <ul class="navbar-nav">
-          <li class="nav-item mr-2">
-            <select multiple
-              id="attributes-select"
-              class="selectpicker"
-              data-style="btn-outline-secondary"
-              data-selected-text-format="count > 3"
-              data-actions-box="true"
-              data-width="auto">
-              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
-              <optgroup id="requirements-select" label="Requirements">
-                <option class="optional" value="optional" title="Optional">Optional Attributes</option>
-                <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
-              </optgroup>
-            </select>
-          </li>
-        </ul>
-      </div>
-    </nav>
-  </div>
 </div>
 
 <div id="network"></div>

--- a/lib/schema_web/templates/page/objects.html.eex
+++ b/lib/schema_web/templates/page/objects.html.eex
@@ -21,23 +21,25 @@ limitations under the License.
   </div>
   <div class="col-md-auto fixed-right mt-2">
     <div class="navbar-expand-md">
-      <div class="form-inline">
-        <ul class="navbar-nav">
-          <li class="nav-item mr-2">
-            <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
-            <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
-          </li>
-          <li class="nav-item">
-            <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-          </li>
-        </ul>
-      </div>
+      <ul class="navbar-nav">
+        <li class="mr-2">
+          <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
+          <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
+        </li>
+        <li>
+          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+          <div class="mt-1">
+            <input type="checkbox" id="show-deprecated" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
+            <label for="show-deprecated">Show deprecated</label>
+          </div>
+        </li>
+      </ul>
     </div>
   </div>
 </div>
 
 <div class="mt-4">
-  <table class="table table-striped table-bordered sortable">
+  <table class="table table-bordered sortable">
     <thead>
       <tr class="thead-color">
         <th style="width: 15%">Name</th>
@@ -47,19 +49,21 @@ limitations under the License.
       </tr>
     </thead>
     <tbody class="searchable">
-      <%= for {key, map} <- @data do %>
-        <% name = Atom.to_string(key) %>
-        <% path = Routes.static_path(@conn, "/objects/" <> name) %>
-        <tr class="ocsf-class" <%= raw format_profiles(map[:profiles])%>>
-          <td class="name"><a href="<%= path %>"><%= name %></a></td>
-          <td class="extensions"><%= raw format_attribute_caption(@conn, name, map) %></td>
-          <td class="extensions"><%= raw object_links(@conn, map[:name], map[:_links], :collapse) %></td>
-          <td><%= raw description(map) %></td>
+      <%= for {object_key, object} <- @data do %>
+        <% object_key_str = Atom.to_string(object_key) %>
+        <% object_path = Routes.static_path(@conn, "/objects/" <> object_key_str) %>
+        <tr class="<%= show_deprecated_css_classes(object, "ocsf-class") %>" <%= raw format_profiles(object[:profiles])%>>
+          <td class="name"><a href="<%= object_path %>"><%= object_key_str %></a></td>
+          <td class="extensions"><%= raw format_attribute_caption(@conn, object_key_str, object) %></td>
+          <td class="extensions"><%= raw object_links(@conn, object[:name], object[:_links], :collapse) %></td>
+          <td><%= raw description(object) %></td>
         </tr>
       <% end %>
     </tbody>
   </table>
 </div>
+
 <script>
   init_class_profiles();
+  init_show_deprecated();
 </script>

--- a/lib/schema_web/templates/page/profile.html.eex
+++ b/lib/schema_web/templates/page/profile.html.eex
@@ -28,34 +28,35 @@
   </div>
   <div class="col-md-auto fixed-right mt-2">
     <div class="navbar-expand-md">
-      <div class="form-inline">
-        <ul class="navbar-nav">
-          <li class="nav-item mr-2">
-            <select multiple
-              id="attributes-select"
-              class="selectpicker"
-              data-style="btn-outline-secondary"
-              data-selected-text-format="count > 3"
-              data-actions-box="true"
-              data-width="auto">
-              <option value="deprecated" title="Deprecated">Deprecated Attributes</option>
-              <optgroup id="groups-select" label="Groups">
-                <option selected value="classification">Classification</option>
-                <option selected value="context">Context</option>
-                <option selected value="occurrence">Occurrence</option>
-                <option selected value="primary">Primary</option>
-              </optgroup>
-              <optgroup id="requirements-select" label="Requirements">
-                <option class="optional" value="optional" title="Optional">Optional Attributes</option>
-                <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
-              </optgroup>
-            </select>
-          </li>
-          <li class="nav-item">
-            <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-          </li>
-        </ul>
-      </div>
+      <ul class="navbar-nav">
+        <li class="nav-item mr-2">
+          <select multiple
+            id="attributes-select"
+            class="selectpicker"
+            data-style="btn-outline-secondary"
+            data-selected-text-format="count > 3"
+            data-actions-box="true"
+            data-width="auto">
+            <optgroup id="groups-select" label="Groups">
+              <option selected value="classification">Classification</option>
+              <option selected value="context">Context</option>
+              <option selected value="occurrence">Occurrence</option>
+              <option selected value="primary">Primary</option>
+            </optgroup>
+            <optgroup id="requirements-select" label="Requirements">
+              <option class="optional" value="optional" title="Optional">Optional Attributes</option>
+              <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
+            </optgroup>
+          </select>
+        </li>
+        <li class="nav-item">
+          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+          <div class="mt-1">
+            <input type="checkbox" id="show-deprecated" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
+            <label for="show-deprecated">Show deprecated</label>
+          </div>
+        </li>
+      </ul>
     </div>
   </div>
 </div>
@@ -95,7 +96,9 @@
     <%= raw profile_links(@conn, @data[:name], links) %>
   </div>
 <% end %>
+
 <script>
   init_schema_buttons();
   init_class_profiles();
+  init_show_deprecated();
 </script>

--- a/lib/schema_web/templates/page/profile.html.eex
+++ b/lib/schema_web/templates/page/profile.html.eex
@@ -92,7 +92,7 @@
   <div></div>
 <% else %>
   <a class="h5 links dropdown-toggle" data-toggle="collapse" data-target="#profile-links" aria-expanded="false" aria-controls="object-links">Referenced By</a>
-  <div class="extensions collapse" id="profile-links">
+  <div class="references extensions collapse" id="profile-links">
     <%= raw profile_links(@conn, @data[:name], links) %>
   </div>
 <% end %>

--- a/lib/schema_web/templates/page/profiles.html.eex
+++ b/lib/schema_web/templates/page/profiles.html.eex
@@ -18,17 +18,19 @@ limitations under the License.
   </div>
   <div class="col-md-auto fixed-right mt-2">
     <div class="navbar-expand-md">
-      <div class="form-inline">
-        <ul class="navbar-nav">
-          <li class="nav-item mr-2">
-            <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
-            <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
-          </li>
-          <li class="nav-item">
-            <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-          </li>
-        </ul>
-      </div>
+      <ul class="navbar-nav">
+        <li class="nav-item mr-2">
+          <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
+          <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
+        </li>
+        <li class="nav-item">
+          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+          <div class="mt-1">
+            <input type="checkbox" id="show-deprecated" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
+            <label for="show-deprecated">Show deprecated</label>
+          </div>
+        </li>
+      </ul>
     </div>
   </div>
 </div>
@@ -48,7 +50,7 @@ limitations under the License.
         <% path = Routes.static_path(@conn, "/profiles/" <> name) %>
         <tr>
           <td class="name"><a href="<%= path %>"><%= name %></a></td>
-          <td><a href="<%= path %>"><%= raw format_caption(name, map) %></a></td>
+          <td><%= raw format_caption(name, map) %></td>
           <td><%= raw profile_links(@conn, map[:name], map[:_links], :collapse) %></td>
           <td><%= raw map[:description] %></td>
         </tr>
@@ -56,6 +58,8 @@ limitations under the License.
     </tbody>
   </table>
 </div>
+
 <script>
   init_class_profiles();
+  init_show_deprecated();
 </script>

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -838,9 +838,9 @@ defmodule SchemaWeb.PageView do
 
   defp link_css_classes(link) do
     if link[:deprecated?] == true do
-      "m-0 collapse deprecated"
+      "reference m-0 collapse deprecated"
     else
-      "m-0"
+      "reference m-0"
     end
   end
 

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -367,47 +367,43 @@ defmodule SchemaWeb.PageView do
 
   @spec field_classes(map) :: nonempty_binary
   def field_classes(field) do
-    base =
+    css_classes =
       if field[:_source] == :base_event or field[:_source] == :event do
         "base-event "
       else
         "event "
       end
 
-    deprecation_status =
-      if field[:"@deprecated"] != nil do
-        base <> "deprecated "
-      else
-        base <> "not-deprecated "
-      end
-
-    classes =
+    css_classes =
       if required?(field) do
-        deprecation_status <> "required "
+        css_classes <> "required "
       else
         if recommended?(field) do
-          deprecation_status <> "recommended "
+          css_classes <> "recommended "
         else
-          deprecation_status <> "optional "
+          css_classes <> "optional "
         end
       end
 
     group = field[:group]
 
-    classes =
+    css_classes =
       if group != nil do
-        classes <> group
+        css_classes <> group
       else
-        classes <> "no-group"
+        css_classes <> "no-group"
       end
 
     profile = field[:profile]
 
-    if profile != nil do
-      classes <> " " <> String.replace(profile, "/", "-")
-    else
-      classes <> " no-profile"
-    end
+    css_classes =
+      if profile != nil do
+        css_classes <> " " <> String.replace(profile, "/", "-")
+      else
+        css_classes <> " no-profile"
+      end
+
+    show_deprecated_css_classes(field, css_classes)
   end
 
   defp required?(field) do
@@ -601,9 +597,12 @@ defmodule SchemaWeb.PageView do
             [],
             fn {id, item}, acc ->
               id = to_string(id)
+              css_classes = show_deprecated_css_classes(item, "bg-transparent")
 
               [
-                "<tr class=\"bg-transparent\"><td style=\"width: 25px\" class=\"text-right\" id=\"",
+                "<tr class=\"",
+                css_classes,
+                "\"><td style=\"width: 25px\" class=\"text-right\" id=\"",
                 to_string(attribute_key),
                 "-",
                 id,
@@ -827,15 +826,22 @@ defmodule SchemaWeb.PageView do
       fn _link, acc ->
         [
           [
-            "<a href=\"",
+            "<div class=\"m-0\"><a href=\"",
             SchemaWeb.Router.Helpers.static_path(conn, "/classes/base_event"),
-            "\" data-toggle=\"tooltip\ title=\"Directly referenced\">Base Event Class</a>"
+            "\" data-toggle=\"tooltip\" title=\"Directly referenced\">Base Event Class</a></div>"
           ]
           | acc
         ]
       end
     )
-    |> Enum.intersperse("<br>")
+  end
+
+  defp link_css_classes(link) do
+    if link[:deprecated?] == true do
+      "m-0 collapse deprecated"
+    else
+      "m-0"
+    end
   end
 
   defp link_deprecated(link) do
@@ -868,13 +874,15 @@ defmodule SchemaWeb.PageView do
               # This means the attribute's :_source is incorrectly missing. Show with warning.
               [
                 [
-                  "<a href=\"",
+                  "<div class=\"",
+                  link_css_classes(link),
+                  "\"><a href=\"",
                   type_path,
                   "\" data-toggle=\"tooltip\" title=\"No source\">",
                   link[:caption],
                   " Class</a>",
                   link_deprecated(link),
-                  " <span class=\"bg-warning\">No source</span>"
+                  " <span class=\"bg-warning\">No source</span></div>"
                 ]
                 | acc
               ]
@@ -882,12 +890,15 @@ defmodule SchemaWeb.PageView do
             source == class_key ->
               [
                 [
-                  "<a href=\"",
+                  "<div class=\"",
+                  link_css_classes(link),
+                  "\"><a href=\"",
                   type_path,
                   "\" data-toggle=\"tooltip\" title=\"Directly referenced\">",
                   link[:caption],
                   " Class</a>",
-                  link_deprecated(link)
+                  link_deprecated(link),
+                  "</div>"
                 ]
                 | acc
               ]
@@ -899,14 +910,17 @@ defmodule SchemaWeb.PageView do
               if ok do
                 [
                   [
-                    "<a href=\"",
+                    "<div class=\"",
+                    link_css_classes(link),
+                    "\"><a href=\"",
                     type_path,
                     "\" data-toggle=\"tooltip\" title=\"Indirectly referenced: ",
                     format_hierarchy(path, all_classes, "class"),
                     "\">",
                     link[:caption],
                     " Class</a>",
-                    link_deprecated(link)
+                    link_deprecated(link),
+                    "</div>"
                   ]
                   | acc
                 ]
@@ -914,13 +928,16 @@ defmodule SchemaWeb.PageView do
                 # This means there's a bad class hierarchy. Show with warning.
                 [
                   [
+                    "<div class=\"",
+                    link_css_classes(link),
+                    "\"><a href=\"",
                     "<a href=\"",
                     type_path,
                     "\" data-toggle=\"tooltip\" title=\"Referenced via unknown parent\">",
                     link[:caption],
                     " Class</a>",
                     link_deprecated(link),
-                    " <span class=\"bg-warning\">Unknown parent</span>"
+                    " <span class=\"bg-warning\">Unknown parent</span></div>"
                   ]
                   | acc
                 ]
@@ -934,10 +951,22 @@ defmodule SchemaWeb.PageView do
     else
       noun_text = if length(html_list) == 1, do: " class", else: " classes"
 
+      deprecated_count =
+        Enum.reduce(linked_classes, 0, fn link, acc ->
+          if link[:deprecated?], do: acc + 1, else: acc
+        end)
+
+      deprecated_text =
+        if deprecated_count > 0 do
+          [" (", to_string(deprecated_count), " deprecated)"]
+        else
+          ""
+        end
+
       collapse_html(
         ["class-links-", to_css_selector(attribute_name)],
-        ["Referenced by ", Integer.to_string(length(html_list)), noun_text],
-        Enum.intersperse(html_list, "<br>")
+        ["Referenced by ", Integer.to_string(length(html_list)), noun_text, deprecated_text],
+        html_list
       )
     end
   end
@@ -949,11 +978,11 @@ defmodule SchemaWeb.PageView do
     all_classes = Schema.all_classes()
     attribute_key = Schema.Utils.descope_to_uid(attribute_name)
 
-    html_list =
+    {html_list, deprecated_count} =
       reverse_sort_links(linked_classes)
       |> Enum.reduce(
-        [],
-        fn link, acc ->
+        {[], 0},
+        fn link, {html_list, deprecated_count} ->
           class_key = Schema.Utils.to_uid(link[:type])
 
           type_path = SchemaWeb.Router.Helpers.static_path(conn, "/classes/" <> link[:type])
@@ -963,70 +992,92 @@ defmodule SchemaWeb.PageView do
           cond do
             source == nil ->
               # This means the attribute's :_source is incorrectly missing. Show with warning.
-              [
+              {
                 [
-                  "<a href=\"",
-                  type_path,
-                  "\" data-toggle=\"tooltip\" title=\"No source\">",
-                  link[:caption],
-                  " Class</a>",
-                  link_deprecated(link),
-                  " <span class=\"bg-warning\">No source</span>"
-                ]
-                | acc
-              ]
+                  [
+                    "<div class=\"",
+                    link_css_classes(link),
+                    "\"><a href=\"",
+                    type_path,
+                    "\" data-toggle=\"tooltip\" title=\"No source\">",
+                    link[:caption],
+                    " Class</a>",
+                    link_deprecated(link),
+                    " <span class=\"bg-warning\">No source</span></div>"
+                  ]
+                  | html_list
+                ],
+                deprecated_count + if(link[:deprecated?], do: 1, else: 0)
+              }
 
             source == :base_event ->
               # Skip base_event source:
               #   - Reduces noise
               #   - It is redundant with showing Base Event Class separately
-              acc
+              {html_list, deprecated_count}
 
             source == class_key ->
-              [
+              {
                 [
-                  "<a href=\"",
-                  type_path,
-                  "\" data-toggle=\"tooltip\" title=\"Directly updated\">",
-                  link[:caption],
-                  " Class</a>",
-                  link_deprecated(link)
-                ]
-                | acc
-              ]
+                  [
+                    "<div class=\"",
+                    link_css_classes(link),
+                    "\"><a href=\"",
+                    type_path,
+                    "\" data-toggle=\"tooltip\" title=\"Directly updated\">",
+                    link[:caption],
+                    " Class</a>",
+                    link_deprecated(link),
+                    "</div>"
+                  ]
+                  | html_list
+                ],
+                deprecated_count + if(link[:deprecated?], do: 1, else: 0)
+              }
 
             true ->
               # Any indirect situation, including through hidden classes
               {ok, path} = build_hierarchy(class_key, source, all_classes)
 
               if ok do
-                [
+                {
                   [
-                    "<a href=\"",
-                    type_path,
-                    "\" data-toggle=\"tooltip\" title=\"Indirectly updated: ",
-                    format_hierarchy(path, all_classes, "class"),
-                    "\">",
-                    link[:caption],
-                    " Class</a>",
-                    link_deprecated(link)
-                  ]
-                  | acc
-                ]
+                    [
+                      "<div class=\"",
+                      link_css_classes(link),
+                      "\"><a href=\"",
+                      type_path,
+                      "\" data-toggle=\"tooltip\" title=\"Indirectly updated: ",
+                      format_hierarchy(path, all_classes, "class"),
+                      "\">",
+                      link[:caption],
+                      " Class</a>",
+                      link_deprecated(link),
+                      "</div>"
+                    ]
+                    | html_list
+                  ],
+                  deprecated_count + if(link[:deprecated?], do: 1, else: 0)
+                }
               else
                 # This means there's a bad class hierarchy. Show with warning.
-                [
+                {
                   [
-                    "<a href=\"",
-                    type_path,
-                    "\" data-toggle=\"tooltip\" title=\"Updated via unknown parent\">",
-                    link[:caption],
-                    " Class</a>",
-                    link_deprecated(link),
-                    " <span class=\"bg-warning\">Unknown parent</span>"
-                  ]
-                  | acc
-                ]
+                    [
+                      "<div class=\"",
+                      link_css_classes(link),
+                      "\"><a href=\"",
+                      type_path,
+                      "\" data-toggle=\"tooltip\" title=\"Updated via unknown parent\">",
+                      link[:caption],
+                      " Class</a>",
+                      link_deprecated(link),
+                      " <span class=\"bg-warning\">Unknown parent</span></div>"
+                    ]
+                    | html_list
+                  ],
+                  deprecated_count + if(link[:deprecated?], do: 1, else: 0)
+                }
               end
           end
         end
@@ -1037,14 +1088,22 @@ defmodule SchemaWeb.PageView do
     else
       noun_text = if length(html_list) == 1, do: " class", else: " classes"
 
+      deprecated_text =
+        if deprecated_count > 0 do
+          [" (", to_string(deprecated_count), " deprecated)"]
+        else
+          ""
+        end
+
       collapse_html(
         ["class-links-", to_css_selector(attribute_name)],
         [
           "Updated in ",
           Integer.to_string(length(html_list)),
-          noun_text
+          noun_text,
+          deprecated_text
         ],
-        Enum.intersperse(html_list, "<br>")
+        html_list
       )
     end
   end
@@ -1060,12 +1119,15 @@ defmodule SchemaWeb.PageView do
         fn link, acc ->
           [
             [
-              "<a href=\"",
+              "<div class=\"",
+              link_css_classes(link),
+              "\"><a href=\"",
               SchemaWeb.Router.Helpers.static_path(conn, "/objects/" <> link[:type]),
               "\">",
               link[:caption],
               " Object</a>",
-              link_deprecated(link)
+              link_deprecated(link),
+              "</div>"
             ]
             | acc
           ]
@@ -1079,14 +1141,26 @@ defmodule SchemaWeb.PageView do
       list_presentation == :collapse ->
         noun_text = if length(html_list) == 1, do: " object", else: " objects"
 
+        deprecated_count =
+          Enum.reduce(linked_objects, 0, fn link, acc ->
+            if link[:deprecated?], do: acc + 1, else: acc
+          end)
+
+        deprecated_text =
+          if deprecated_count > 0 do
+            [" (", to_string(deprecated_count), " deprecated)"]
+          else
+            ""
+          end
+
         collapse_html(
           ["object-links-", to_css_selector(name)],
-          ["Referenced by ", Integer.to_string(length(html_list)), noun_text],
-          Enum.intersperse(html_list, "<br>")
+          ["Referenced by ", Integer.to_string(length(html_list)), noun_text, deprecated_text],
+          html_list
         )
 
       true ->
-        Enum.intersperse(html_list, "<br>")
+        html_list
     end
   end
 
@@ -1141,25 +1215,31 @@ defmodule SchemaWeb.PageView do
           [
             if list_presentation == :collapse do
               [
-                "<a href=\"",
+                "<div class=\"",
+                link_css_classes(link),
+                "\"><a href=\"",
                 type_path,
                 "\" data-toggle=\"tooltip\" title=\"",
                 link_attributes(link),
                 "\">",
                 link[:caption],
                 " Class</a>",
-                link_deprecated(link)
+                link_deprecated(link),
+                "</div>"
               ]
             else
               [
-                "<dt><a href=\"",
+                "<div class=\"",
+                link_css_classes(link),
+                "\"><dt><a href=\"",
                 type_path,
                 "\">",
                 link[:caption],
                 " Class</a>",
                 link_deprecated(link),
                 "<dd class=\"ml-3\">",
-                link_attributes(link)
+                link_attributes(link),
+                "</div>"
               ]
             end
             | acc
@@ -1172,7 +1252,7 @@ defmodule SchemaWeb.PageView do
         []
 
       list_presentation == :collapse ->
-        Enum.intersperse(html_list, "<br>")
+        html_list
 
       true ->
         ["<dl class=\"m-0\">", html_list, "</dl>"]
@@ -1192,25 +1272,31 @@ defmodule SchemaWeb.PageView do
           [
             if list_presentation == :collapse do
               [
-                "<a href=\"",
+                "<div class=\"",
+                link_css_classes(link),
+                "\"><a href=\"",
                 type_path,
                 "\" data-toggle=\"tooltip\" title=\"",
                 link_attributes(link),
                 "\">",
                 link[:caption],
                 " Class</a>",
-                link_deprecated(link)
+                link_deprecated(link),
+                "</div>"
               ]
             else
               [
-                "<dt><a href=\"",
+                "<div class=\"",
+                link_css_classes(link),
+                "\"><dt><a href=\"",
                 type_path,
                 "\">",
                 link[:caption],
                 " Class</a>",
                 link_deprecated(link),
                 "<dd class=\"ml-3\">",
-                link_attributes(link)
+                link_attributes(link),
+                "</div>"
               ]
             end
             | acc
@@ -1225,10 +1311,22 @@ defmodule SchemaWeb.PageView do
       list_presentation == :collapse ->
         noun_text = if length(html_list) == 1, do: " class", else: " classes"
 
+        deprecated_count =
+          Enum.reduce(linked_classes, 0, fn link, acc ->
+            if link[:deprecated?], do: acc + 1, else: acc
+          end)
+
+        deprecated_text =
+          if deprecated_count > 0 do
+            [" (", to_string(deprecated_count), " deprecated)"]
+          else
+            ""
+          end
+
         collapse_html(
           ["class-links-", to_css_selector(name)],
-          ["Referenced by ", Integer.to_string(length(html_list)), noun_text],
-          Enum.intersperse(html_list, "<br>")
+          ["Referenced by ", Integer.to_string(length(html_list)), noun_text, deprecated_text],
+          html_list
         )
 
       true ->
@@ -1249,25 +1347,31 @@ defmodule SchemaWeb.PageView do
           [
             if list_presentation == :collapse do
               [
-                "<a href=\"",
+                "<div class=\"",
+                link_css_classes(link),
+                "\"><a href=\"",
                 type_path,
                 "\" data-toggle=\"tooltip\" title=\"",
                 link_attributes(link),
                 "\">",
                 link[:caption],
                 " Object</a>",
-                link_deprecated(link)
+                link_deprecated(link),
+                "</div>"
               ]
             else
               [
-                "<dt><a href=\"",
+                "<div class=\"",
+                link_css_classes(link),
+                "\"><dt><a href=\"",
                 type_path,
                 "\">",
                 link[:caption],
                 " Object</a>",
                 link_deprecated(link),
                 "<dd class=\"ml-3\">",
-                link_attributes(link)
+                link_attributes(link),
+                "</div>"
               ]
             end
             | acc
@@ -1282,10 +1386,22 @@ defmodule SchemaWeb.PageView do
       list_presentation == :collapse ->
         noun_text = if length(html_list) == 1, do: " object", else: " objects"
 
+        deprecated_count =
+          Enum.reduce(linked_objects, 0, fn link, acc ->
+            if link[:deprecated?], do: acc + 1, else: acc
+          end)
+
+        deprecated_text =
+          if deprecated_count > 0 do
+            [" (", to_string(deprecated_count), " deprecated)"]
+          else
+            ""
+          end
+
         collapse_html(
           ["object-links-", to_css_selector(name)],
-          ["Referenced by ", Integer.to_string(length(html_list)), noun_text],
-          Enum.intersperse(html_list, "<br>")
+          ["Referenced by ", Integer.to_string(length(html_list)), noun_text, deprecated_text],
+          html_list
         )
 
       true ->
@@ -1322,15 +1438,14 @@ defmodule SchemaWeb.PageView do
       fn _link, acc ->
         [
           [
-            "<a href=\"",
+            "<div class=\"m-0\"><a href=\"",
             SchemaWeb.Router.Helpers.static_path(conn, "/classes/base_event"),
-            "\">Base Event Class</a>"
+            "\">Base Event Class</a></div>"
           ]
           | acc
         ]
       end
     )
-    |> Enum.intersperse("<br>")
   end
 
   defp profile_links_class_to_html(_, _, nil, _), do: []
@@ -1343,12 +1458,15 @@ defmodule SchemaWeb.PageView do
         fn link, acc ->
           [
             [
-              "<a href=\"",
+              "<div class=\"",
+              link_css_classes(link),
+              "\"><a href=\"",
               SchemaWeb.Router.Helpers.static_path(conn, "/classes/" <> link[:type]),
               "\">",
               link[:caption],
               " Class</a>",
-              link_deprecated(link)
+              link_deprecated(link),
+              "</div>"
             ]
             | acc
           ]
@@ -1362,14 +1480,26 @@ defmodule SchemaWeb.PageView do
       list_presentation == :collapse ->
         noun_text = if length(html_list) == 1, do: " class", else: " classes"
 
+        deprecated_count =
+          Enum.reduce(linked_classes, 0, fn link, acc ->
+            if link[:deprecated?], do: acc + 1, else: acc
+          end)
+
+        deprecated_text =
+          if deprecated_count > 0 do
+            [" (", to_string(deprecated_count), " deprecated)"]
+          else
+            ""
+          end
+
         collapse_html(
           ["class-links-", to_css_selector(profile_name)],
-          ["Referenced by ", Integer.to_string(length(html_list)), noun_text],
-          Enum.intersperse(html_list, "<br>")
+          ["Referenced by ", Integer.to_string(length(html_list)), noun_text, deprecated_text],
+          html_list
         )
 
       true ->
-        Enum.intersperse(html_list, "<br>")
+        html_list
     end
   end
 
@@ -1414,5 +1544,10 @@ defmodule SchemaWeb.PageView do
     else
       initial
     end
+  end
+
+  @spec show_deprecated_css_classes(map()) :: String.t()
+  def show_deprecated_css_classes(item) do
+    show_deprecated_css_classes(item, "")
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "2.79.0"
+  @version "2.79.1"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -386,3 +386,19 @@ section.category header a {
 section.category div.ocsf-class {
   margin-left: 1em;
 }
+
+div.references {
+  border: 1px solid;
+  border-color: rgb(222, 226, 230);
+  padding: 1em;
+  margin-bottom: 1em;
+  -webkit-columns: 4 18rem;
+     -moz-columns: 4 18rem;
+          columns: 4 18rem;
+}
+
+div.references div.reference {
+  -webkit-break-inside: avoid;
+     -moz-break-inside: avoid;
+          break-inside: avoid;
+}

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -99,7 +99,6 @@ function display_attributes(options) {
   if (table != null) {
     // add CSS classes that are always shown
     options.add("event");
-    options.add("not-deprecated")
     options.add("required");
     options.add("no-group");
     options.add("no-profile");
@@ -134,7 +133,7 @@ function intersection(setA, setB) {
 }
 
 function display_row(set, classList) {
-  if (set.size == 5)
+  if (set.size == 4)
     classList.remove('d-none');
   else
     classList.add('d-none');


### PR DESCRIPTION
Follow up to last show/hide PR. This extends the "Show deprecated classes" idea to a "Show deprecated" checkbox everywhere for all things: classes, objects, attributes, and enum values. This includes classes and objects in "referenced by" lists.

The "Deprecated" selection in the attribute droplist filter is removed in favor of the general "Show deprecated" checkbox.

The idea is that someone creating new events should not use hide deprecated, while someone getting information about existing events can show deprecated.