### PR TITLE
[bugfix] for datetime profile construction in extended objects

### DIFF
--- a/lib/schema/cache.ex
+++ b/lib/schema/cache.ex
@@ -1191,7 +1191,7 @@ defmodule Schema.Cache do
     list =
       Enum.reduce(attributes, [], fn {key, attribute}, acc ->
         missing_desc_warning(attribute[:description], name, key, dictionary)
-        add_datetime(Utils.find_entity(dictionary, map, key), key, attribute, acc)
+        add_datetime(find_attribute(dictionary, key, attribute[:_source]), key, attribute, acc)
       end)
 
     update_profiles(list, map, profiles, attributes)
@@ -1209,11 +1209,11 @@ defmodule Schema.Cache do
     :ok
   end
 
-  defp add_datetime({_k, nil}, _key, _attribute, acc) do
+  defp add_datetime(nil, _key, _attribute, acc) do
     acc
   end
 
-  defp add_datetime({_k, v}, key, attribute, acc) do
+  defp add_datetime(v, key, attribute, acc) do
     case Map.get(v, :type) do
       "timestamp_t" ->
         attribute =


### PR DESCRIPTION
Resolves #146 

The issue noted above, explains the current bug in detail. This PR addresses that bug, now all the timestamp attributes added in extended objects, will correctly have the shadow `datetime` fields.