### PR TITLE
Revert Docker Elixir image to 1.18.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG elixir_image=elixir:1.18.4-alpine
+ARG elixir_image=elixir:1.18.3-alpine
 
 FROM ${elixir_image} AS builder
 


### PR DESCRIPTION
Revert Docker Elixir image to 1.18.3 since 1.18.4 does not work for arm64 build.