### PR TITLE
Adding a changelog link in the sidebar

### DIFF
--- a/lib/schema_web/templates/layout/app.html.eex
+++ b/lib/schema_web/templates/layout/app.html.eex
@@ -150,6 +150,12 @@ limitations under the License.
         window.open(x, "_self");
       }
       </script>
+      <div class="changelog-container">
+        <a class="changelog-link" target="_blank" href="https://github.com/ocsf/ocsf-schema/blob/main/CHANGELOG.md">
+          <i class="fas fa-history"></i>
+          Changelog
+        </a>
+      </div>
     </div>
 
     <!-- Sidebar Content - Scrollable -->

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "3.0.0"
+  @version "3.0.1"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/priv/static/css/layout.css
+++ b/priv/static/css/layout.css
@@ -133,8 +133,30 @@
 }
 
 /* Version Selector - Shared Styles */
+/* Changelog Link Positioning */
+.changelog-container {
+  margin-top: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+}
+
+.changelog-link {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  color: var(--primary-color);
+  text-decoration: none;
+  font-size: 0.875rem;
+}
+
+.changelog-link:hover,
+.changelog-link:active,
+.changelog-link:focus {
+  color: var(--accent-color);
+  text-decoration: none;
+}
+
 .version {
-  margin-bottom: var(--spacing-xl);
+  margin-bottom: var(--spacing-lg);
 }
 
 .select-version {
@@ -498,6 +520,28 @@
   .navbar-collapse a:hover,
   .navbar-collapse a:focus,
   .navbar-collapse a:active {
+    color: var(--accent-color) !important;
+  }
+
+  /* Mobile changelog link overrides */
+  .navbar-collapse .changelog-link {
+    color: var(--primary-color) !important;
+  }
+
+  .navbar-collapse .changelog-link:hover,
+  .navbar-collapse .changelog-link:active,
+  .navbar-collapse .changelog-link:focus {
+    color: var(--accent-color) !important;
+  }
+
+  /* Mobile changelog link icon overrides */
+  .navbar-collapse .changelog-link i {
+    color: var(--primary-color) !important;
+  }
+
+  .navbar-collapse .changelog-link:hover i,
+  .navbar-collapse .changelog-link:active i,
+  .navbar-collapse .changelog-link:focus i {
     color: var(--accent-color) !important;
   }
 


### PR DESCRIPTION
A quick one: Adding link to the changelog in the sidebar, below the version selector.

![Screenshot 2025-07-07 at 14 44 57](https://github.com/user-attachments/assets/3c9bcfcd-10bb-4c77-9108-574f3b5eee29)


![Screenshot 2025-07-07 at 14 44 50](https://github.com/user-attachments/assets/c87688e9-d111-4885-aa6d-2e7e763cbc97)
