### PR TITLE
Bug fix for #162, Layout Improvements and improving shareability of specific configurations

### DIFF
--- a/lib/schema_web/controllers/page_controller.ex
+++ b/lib/schema_web/controllers/page_controller.ex
@@ -162,8 +162,9 @@ defmodule SchemaWeb.PageController do
   @spec classes(Plug.Conn.t(), any) :: Plug.Conn.t()
   def classes(conn, %{"id" => id} = params) do
     extension = params["extension"]
+    profiles = parse_profiles_from_params(params)
 
-    case Schema.class(extension, id) do
+    case Schema.class(extension, id, profiles) do
       nil ->
         send_resp(conn, 404, "Not Found: #{id}")
 
@@ -248,5 +249,17 @@ defmodule SchemaWeb.PageController do
     Enum.sort(map, fn {k1, _}, {k2, _} ->
       Schema.Utils.descope(k1) <= Schema.Utils.descope(k2)
     end)
+  end
+
+  defp parse_profiles_from_params(params) do
+    case params["profiles"] do
+      nil -> nil
+      "" -> MapSet.new()
+      profiles_string ->
+        profiles_string
+        |> String.split(",")
+        |> Enum.map(&String.trim/1)
+        |> MapSet.new()
+    end
   end
 end

--- a/lib/schema_web/templates/layout/app.html.eex
+++ b/lib/schema_web/templates/layout/app.html.eex
@@ -210,6 +210,24 @@ limitations under the License.
         </div>
       </div>
       <% end %>
+
+      <!-- Display Options Section -->
+      <div class="sidebar-section">
+        <div class="sidebar-section-header">
+          <i class="fas fa-cog"></i> Options
+          <hr class="divider"/>
+        </div>
+        <div class="sidebar-section-content">
+          <ul class="sidebar-nav">
+            <li class="sidebar-nav-item">
+              <label>
+                <input type="checkbox" id="show-deprecated-global" class="show-deprecated-checkbox" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
+                Show deprecated items
+              </label>
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
 
   </nav>

--- a/lib/schema_web/templates/layout/app.html.eex
+++ b/lib/schema_web/templates/layout/app.html.eex
@@ -34,13 +34,20 @@ limitations under the License.
       if (document.readyState === 'interactive')
       {
         let selected_extensions = get_selected_extensions();
+        let selected_profiles = get_selected_profiles();
+
         $.each(selected_extensions, function(key, value) {
           $("#" + key).prop('checked', value);
         });
 
-        // update the links with the selected extensions
-        const params = select_extensions(selected_extensions);
+        // update the links with the selected extensions and profiles
+        const params = build_url_params(selected_extensions, selected_profiles);
         $(".sidebar-section a").each(function() {
+          this.href = this.href + params;
+        });
+
+        // Also update main navigation links
+        $(".top-navbar-nav a.nav-link").each(function() {
           this.href = this.href + params;
         });
 
@@ -61,11 +68,10 @@ limitations under the License.
         });
         set_selected_extensions(selected_extensions);
 
-        const params = select_extensions(selected_extensions);
+        // Get current profiles and build complete URL
+        const selected_profiles = get_selected_profiles();
+        const params = build_url_params(selected_extensions, selected_profiles);
         window.location.search = params;
-        $(".sidebar-section a").each(function() {
-          this.href = this.href + params;
-        });
       });
 
       // init the attributes dropdown filters

--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -55,6 +55,9 @@ limitations under the License.
             <button type="button" id="btn-sample-data" class="btn-sm" title="View Sample Data">
               Sample
             </button>
+            <button type="button" id="btn-validate" class="btn-sm" title="Validation API">
+              Validate
+            </button>
           </div>
         </li>
         <li class="nav-item mr-2">

--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -34,68 +34,44 @@ limitations under the License.
          Category
       </h4>
     <% end %>
-    <div class="text-secondary">
+
+    <div class="text-secondary description-content">
       <%= raw description(@data) %>
     </div>
+    <%= if observables != nil and !Enum.empty?(observables) do %>
     <div class="text-secondary mt-2">
-      <strong>Note:</strong> a superscript &quot;O&quot; after a caption indicates attribute is an observable.
-      <%= if observables != nil and !Enum.empty?(observables) do %>Class-specific attribute path observables
-      are <a href="#observables">at the bottom of this page</a>.<% end %>
+      Class-specific attribute path observables are <a href="#observables">at the bottom of this page</a>.
     </div>
+    <% end %>
     <%= raw object_references_section(references) %>
   </div>
-  <div class="col-md-auto fixed-right mt-2">
-    <div class="navbar-expand-md">
-      <ul class="navbar-nav">
-        <li class="nav-item mr-2">
-          <div class="btn-group" role="group" aria-label="Schema actions">
-            <button type="button" id="btn-json-schema" class="btn-sm" title="View JSON Schema">
-              JSON Schema
-            </button>
-            <button type="button" id="btn-sample-data" class="btn-sm" title="View Sample Data">
-              Sample
-            </button>
-            <button type="button" id="btn-validate" class="btn-sm" title="Validation API">
-              Validate
-            </button>
-          </div>
-        </li>
-        <li class="nav-item mr-2">
-          <select multiple
-            id="attributes-select"
-            class="selectpicker"
-            data-style="btn-outline-secondary"
-            data-selected-text-format="count > 3"
-            data-actions-box="true"
-            data-width="auto">
-            <option selected id="base-event-select" class="base-event" value="base-event" title="Base Event">Base
-              Event Attributes
-            </option>
-            <optgroup id="groups-select" label="Groups">
-              <option selected value="classification">Classification</option>
-              <option selected value="context">Context</option>
-              <option selected value="occurrence">Occurrence</option>
-              <option selected value="primary">Primary</option>
-            </optgroup>
-            <optgroup id="requirements-select" label="Requirements">
-              <option class="optional" value="optional" title="Optional">Optional Attributes</option>
-              <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
-            </optgroup>
-          </select>
-        </li>
-        <li class="nav-item">
-          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-          <div class="mt-1">
-            <div class="show-deprecated-container">
-              <input type="checkbox" id="show-deprecated" class="show-deprecated-checkbox" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
-              <label for="show-deprecated" class="show-deprecated-label">
-                <span class="show-deprecated-text">Show deprecated</span>
-              </label>
-            </div>
-          </div>
-        </li>
-      </ul>
+  <div class="navbar-nav col-md-auto fixed-right mt-2">
+    <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+  </div>
+</div>
+
+<div class="row align-items-center mb-3">
+  <div class="col-auto">
+    <div class="btn-group" role="group" aria-label="Schema actions">
+      <button type="button" id="btn-json-schema" class="btn btn-sm btn-outline-primary" title="View JSON Schema">JSON Schema</button>
+      <button type="button" id="btn-sample-data" class="btn btn-sm btn-outline-primary" title="View Sample Data">Sample</button>
+      <button type="button" id="btn-validate" class="btn btn-sm btn-outline-primary" title="Validation API">Validate</button>
     </div>
+  </div>
+  <div class="col-auto">
+    <select multiple id="attributes-select" class="selectpicker" data-style="btn-outline-secondary" data-selected-text-format="count > 3" data-actions-box="true" data-width="auto">
+      <option selected id="base-event-select" class="base-event" value="base-event" title="Base Event">Base Event Attributes</option>
+      <optgroup id="groups-select" label="Groups">
+        <option selected value="classification">Classification</option>
+        <option selected value="context">Context</option>
+        <option selected value="occurrence">Occurrence</option>
+        <option selected value="primary">Primary</option>
+      </optgroup>
+      <optgroup id="requirements-select" label="Requirements">
+        <option class="optional" value="optional" title="Optional">Optional Attributes</option>
+        <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
+      </optgroup>
+    </select>
   </div>
 </div>
 

--- a/lib/schema_web/templates/page/classes.html.eex
+++ b/lib/schema_web/templates/page/classes.html.eex
@@ -12,20 +12,12 @@ limitations under the License.
 <div class="row">
   <div class="col-md move-up">
     <h3>Classes</h3>
-    <div class="text-secondary">
-      The OCSF event classes.
+    <div class="text-secondary description-content">
+      The list of all the OCSF event classes, currently available.
     </div>
   </div>
   <div class="navbar-nav col-md-auto fixed-right mt-2">
     <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-    <div class="mt-1">
-      <div class="show-deprecated-container">
-        <input type="checkbox" id="show-deprecated" class="show-deprecated-checkbox" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
-        <label for="show-deprecated" class="show-deprecated-label">
-          <span class="show-deprecated-text">Show deprecated</span>
-        </label>
-      </div>
-    </div>
   </div>
 </div>
 

--- a/lib/schema_web/templates/page/data_types.html.eex
+++ b/lib/schema_web/templates/page/data_types.html.eex
@@ -14,11 +14,8 @@ limitations under the License.
     <h3>
       <%= @data[:caption] %>
     </h3>
-    <div class="text-secondary">
+    <div class="text-secondary description-content">
       <%= raw @data[:description] %>
-    </div>
-    <div class="text-secondary mt-2">
-      <strong>Note:</strong> a superscript &quot;O&quot; after a caption indicates type is an observable.
     </div>
   </div>
 </div>

--- a/lib/schema_web/templates/page/dictionary.html.eex
+++ b/lib/schema_web/templates/page/dictionary.html.eex
@@ -13,7 +13,7 @@ limitations under the License.
 <div class="row">
   <div class="col-md move-up">
     <h3><%= @data[:caption] %></h3>
-    <div class="text-secondary">
+    <div class="text-secondary description-content">
       <%= raw @data[:description] %>
     </div>
     <div class="text-secondary mt-2">
@@ -22,25 +22,15 @@ limitations under the License.
     </div>
   </div>
   <div class="col-md-auto fixed-right mt-2">
-    <div class="navbar-expand-md">
-      <ul class="navbar-nav">
-        <li class="nav-item mr-2">
-          <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
-          <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
-          <br><small>Expand All and Collapse All are slow &mdash; be patient</small>
-        </li>
-        <li class="nav-item">
-          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-          <div class="mt-1">
-            <div class="show-deprecated-container">
-              <input type="checkbox" id="show-deprecated" class="show-deprecated-checkbox" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
-              <label for="show-deprecated" class="show-deprecated-label">
-                <span class="show-deprecated-text">Show deprecated</span>
-              </label>
-            </div>
-          </div>
-        </li>
-      </ul>
+    <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+    <div class="mt-3">
+      <div class="btn-group d-flex" role="group" aria-label="Dictionary actions">
+        <button type="button" title="Expand all references" class="btn btn-sm btn-outline-primary" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
+        <button type="button" title="Collapse all references" class="btn btn-sm btn-outline-primary" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
+      </div>
+      <div class="mt-1 text-center">
+        <small class="text-muted">Expand All and Collapse All are slow &mdash; be patient</small>
+      </div>
     </div>
   </div>
 </div>

--- a/lib/schema_web/templates/page/index.html.eex
+++ b/lib/schema_web/templates/page/index.html.eex
@@ -13,20 +13,12 @@ limitations under the License.
 <div class="row fade-in">
   <div class="col-md move-up">
     <h3><%= @data[:caption] %></h3>
-    <div class="page-description">
+    <div class="text-secondary description-content">
       <%= raw @data[:description] %>
     </div>
   </div>
   <div class="navbar-nav col-md-auto fixed-right mt-2">
     <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-    <div class="mt-1">
-      <div class="show-deprecated-container">
-        <input type="checkbox" id="show-deprecated" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)" class="show-deprecated-checkbox">
-        <label for="show-deprecated" class="show-deprecated-label">
-          <span class="show-deprecated-text">Show deprecated</span>
-        </label>
-      </div>
-    </div>
   </div>
 </div>
 

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -20,7 +20,7 @@
       <% observable = @data[:observable] %>
       <%= if is_nil(observable) do %>
         <span class="small"><%= if @data[:extension] && @data[:extension] != "" do %><span class="extension-badge"><%= @data[:extension] %></span><% end %>
-          object
+          Object
         </span>
       <% else %>
         <span class="small"><%= if @data[:extension] && @data[:extension] != "" do %><span class="extension-badge"><%= @data[:extension] %></span><% end %>

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -38,54 +38,30 @@
       <%= raw profile_badges(@conn, @data, @profiles) %>
     </h3>
 
-    <div class="text-secondary">
+    <div class="text-secondary description-content">
       <%= raw description(@data) %>
-    </div>
-    <div class="text-secondary mt-2">
-      <strong>Note:</strong> a superscript &quot;O&quot; after a caption indicates attribute is an observable.
     </div>
     <%= raw object_references_section(references) %>
   </div>
-  <div class="col-md-auto fixed-right mt-2">
-    <div class="navbar-expand-md">
-      <ul class="navbar-nav">
-        <li class="nav-item mr-2">
-          <div class="btn-group" role="group" aria-label="Schema actions">
-            <button type="button" id="btn-json-schema" class="btn-sm" title="View JSON Schema">
-              JSON Schema
-            </button>
-            <button type="button" id="btn-sample-data" class="btn-sm" title="View Sample Data">
-              Sample
-            </button>
-          </div>
-        </li>
-        <li class="nav-item mr-2">
-          <select multiple
-            id="attributes-select"
-            class="selectpicker"
-            data-style="btn-outline-secondary"
-            data-selected-text-format="count > 3"
-            data-actions-box="true"
-            data-width="auto">
-            <optgroup id="requirements-select" label="Requirements">
-              <option class="optional" value="optional" title="Optional">Optional Attributes</option>
-              <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
-            </optgroup>
-          </select>
-        </li>
-        <li class="nav-item">
-          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-          <div class="mt-1">
-            <div class="show-deprecated-container">
-              <input type="checkbox" id="show-deprecated" class="show-deprecated-checkbox" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
-              <label for="show-deprecated" class="show-deprecated-label">
-                <span class="show-deprecated-text">Show deprecated</span>
-              </label>
-            </div>
-          </div>
-        </li>
-      </ul>
+  <div class="navbar-nav col-md-auto fixed-right mt-2">
+    <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+  </div>
+</div>
+
+<div class="row align-items-center mb-3">
+  <div class="col-auto">
+    <div class="btn-group" role="group" aria-label="Schema actions">
+      <button type="button" id="btn-json-schema" class="btn btn-sm btn-outline-primary" title="View JSON Schema">JSON Schema</button>
+      <button type="button" id="btn-sample-data" class="btn btn-sm btn-outline-primary" title="View Sample Data">Sample</button>
     </div>
+  </div>
+  <div class="col-auto">
+    <select multiple id="attributes-select" class="selectpicker" data-style="btn-outline-secondary" data-selected-text-format="count > 3" data-actions-box="true" data-width="auto">
+      <optgroup id="requirements-select" label="Requirements">
+        <option class="optional" value="optional" title="Optional">Optional Attributes</option>
+        <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
+      </optgroup>
+    </select>
   </div>
 </div>
 

--- a/lib/schema_web/templates/page/objects.html.eex
+++ b/lib/schema_web/templates/page/objects.html.eex
@@ -12,32 +12,17 @@ limitations under the License.
 <div class="row">
   <div class="col-md move-up">
     <h3>Objects</h3>
-    <div class="text-secondary">
+    <div class="text-secondary description-content">
       The OCSF objects. An object is a complex data type, which is a collection of other attributes. Some objects represent entities or artifacts, but not all.
-    </div>
-    <div class="text-secondary mt-2">
-      <strong>Note:</strong> a superscript &quot;O&quot; after a caption indicates object is an observable.
     </div>
   </div>
   <div class="col-md-auto fixed-right mt-2">
-    <div class="navbar-expand-md">
-      <ul class="navbar-nav">
-        <li class="mr-2">
-          <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
-          <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
-        </li>
-        <li>
-          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-          <div class="mt-1">
-            <div class="show-deprecated-container">
-              <input type="checkbox" id="show-deprecated" class="show-deprecated-checkbox" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
-              <label for="show-deprecated" class="show-deprecated-label">
-                <span class="show-deprecated-text">Show deprecated</span>
-              </label>
-            </div>
-          </div>
-        </li>
-      </ul>
+    <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+    <div class="mt-3">
+      <div class="btn-group d-flex" role="group" aria-label="Objects actions">
+        <button type="button" title="Expand all references" class="btn btn-sm btn-outline-primary" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
+        <button type="button" title="Collapse all references" class="btn btn-sm btn-outline-primary" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
+      </div>
     </div>
   </div>
 </div>

--- a/lib/schema_web/templates/page/profile.html.eex
+++ b/lib/schema_web/templates/page/profile.html.eex
@@ -19,11 +19,8 @@
       </span>
     </h3>
 
-    <div class="text-secondary">
+    <div class="text-secondary description-content">
       <%= raw @data[:description] %>
-    </div>
-    <div class="text-secondary mt-2">
-      <strong>Note:</strong> a superscript &quot;O&quot; after a caption indicates attribute is an observable.
     </div>
   </div>
   <div class="col-md-auto fixed-right mt-2">
@@ -45,14 +42,6 @@
         </li>
         <li class="nav-item">
           <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-          <div class="mt-1">
-            <div class="show-deprecated-container">
-              <input type="checkbox" id="show-deprecated" class="show-deprecated-checkbox" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
-              <label for="show-deprecated" class="show-deprecated-label">
-                <span class="show-deprecated-text">Show deprecated</span>
-              </label>
-            </div>
-          </div>
         </li>
       </ul>
     </div>

--- a/lib/schema_web/templates/page/profile.html.eex
+++ b/lib/schema_web/templates/page/profile.html.eex
@@ -23,28 +23,20 @@
       <%= raw @data[:description] %>
     </div>
   </div>
-  <div class="col-md-auto fixed-right mt-2">
-    <div class="navbar-expand-md">
-      <ul class="navbar-nav">
-        <li class="nav-item mr-2">
-          <select multiple
-            id="attributes-select"
-            class="selectpicker"
-            data-style="btn-outline-secondary"
-            data-selected-text-format="count > 3"
-            data-actions-box="true"
-            data-width="auto">
-            <optgroup id="requirements-select" label="Requirements">
-              <option class="optional" value="optional" title="Optional">Optional Attributes</option>
-              <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
-            </optgroup>
-          </select>
-        </li>
-        <li class="nav-item">
-          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-        </li>
-      </ul>
-    </div>
+  <div class="navbar-nav col-md-auto fixed-right mt-2">
+    <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+  </div>
+</div>
+
+<div class="row align-items-center mb-3">
+  <div class="col"></div>
+  <div class="col-auto">
+    <select multiple id="attributes-select" class="selectpicker" data-style="btn-outline-secondary" data-selected-text-format="count > 3" data-actions-box="true" data-width="auto">
+      <optgroup id="requirements-select" label="Requirements">
+        <option class="optional" value="optional" title="Optional">Optional Attributes</option>
+        <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>
+      </optgroup>
+    </select>
   </div>
 </div>
 

--- a/lib/schema_web/templates/page/profiles.html.eex
+++ b/lib/schema_web/templates/page/profiles.html.eex
@@ -12,29 +12,17 @@ limitations under the License.
 <div class="row">
   <div class="col-md move-up">
     <h3>Profiles</h3>
-    <div class="text-secondary">
+    <div class="text-secondary description-content">
       The OCSF Profiles. A profile is an optional overlay on event classes and objects that reference it.
     </div>
   </div>
   <div class="col-md-auto fixed-right mt-2">
-    <div class="navbar-expand-md">
-      <ul class="navbar-nav">
-        <li class="nav-item mr-2">
-          <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
-          <button class="btn btn-outline-secondary dropdown-toggle" type="button" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
-        </li>
-        <li class="nav-item">
-          <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
-          <div class="mt-1">
-            <div class="show-deprecated-container">
-              <input type="checkbox" id="show-deprecated" class="show-deprecated-checkbox" data-toggle="collapse" data-target=".deprecated" onclick="on_click_show_deprecated(this)">
-              <label for="show-deprecated" class="show-deprecated-label">
-                <span class="show-deprecated-text">Show deprecated</span>
-              </label>
-            </div>
-          </div>
-        </li>
-      </ul>
+    <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+    <div class="mt-3">
+      <div class="btn-group d-flex" role="group" aria-label="Profiles actions">
+        <button type="button" title="Expand all references" class="btn btn-sm btn-outline-primary" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
+        <button type="button" title="Collapse all references" class="btn btn-sm btn-outline-primary" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
+      </div>
     </div>
   </div>
 </div>

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -916,7 +916,9 @@ defmodule SchemaWeb.PageView do
   defp dictionary_links_class_to_html(_, _, nil), do: []
 
   defp dictionary_links_class_to_html(conn, attribute_name, linked_classes) do
-    classes = SchemaController.classes(conn.params)
+    # Strip profiles parameter to get classes with proper source attribution
+    params_without_profiles = Map.delete(conn.params, "profiles")
+    classes = SchemaController.classes(params_without_profiles)
     all_classes = Schema.all_classes()
     attribute_key = Schema.Utils.descope_to_uid(attribute_name)
 
@@ -1035,7 +1037,9 @@ defmodule SchemaWeb.PageView do
   defp dictionary_links_class_updated_to_html(_, _, nil), do: []
 
   defp dictionary_links_class_updated_to_html(conn, attribute_name, linked_classes) do
-    classes = SchemaController.classes(conn.params)
+    # Strip profiles parameter to get classes with proper source attribution
+    params_without_profiles = Map.delete(conn.params, "profiles")
+    classes = SchemaController.classes(params_without_profiles)
     all_classes = Schema.all_classes()
     attribute_key = Schema.Utils.descope_to_uid(attribute_name)
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "3.0.4"
+  @version "3.1.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/priv/static/css/components.css
+++ b/priv/static/css/components.css
@@ -158,7 +158,7 @@ button:hover,
 }
 
 /* Schema Action Buttons */
-#btn-json-schema, #btn-schema, #btn-sample-data {
+#btn-json-schema, #btn-schema, #btn-sample-data, #btn-validate {
   background: var(--primary-color);
   color: var(--text-inverse);
   border-radius: var(--radius-md);
@@ -177,7 +177,7 @@ button:hover,
   justify-content: center;
 }
 
-#btn-json-schema:hover, #btn-schema:hover, #btn-sample-data:hover {
+#btn-json-schema:hover, #btn-schema:hover, #btn-sample-data:hover, #btn-validate:hover {
   background: var(--accent-color);
   border-color: var(--accent-color);
   color: var(--text-inverse);
@@ -186,12 +186,12 @@ button:hover,
   box-shadow: var(--shadow-md);
 }
 
-#btn-json-schema:focus, #btn-schema:focus, #btn-sample-data:focus {
+#btn-json-schema:focus, #btn-schema:focus, #btn-sample-data:focus, #btn-validate:focus {
   outline: none;
   box-shadow: var(--shadow-md), 0 0 0 3px rgba(var(--primary-color-rgb), 0.2);
 }
 
-#btn-json-schema:active, #btn-schema:active, #btn-sample-data:active {
+#btn-json-schema:active, #btn-schema:active, #btn-sample-data:active, #btn-validate:active {
   transform: translateY(0);
   box-shadow: var(--shadow-sm);
 }
@@ -213,6 +213,13 @@ button:hover,
 
 #btn-sample-data::before {
   content: '\f1c0';
+  font-family: 'Font Awesome 6 Free';
+  font-weight: 900;
+  margin-right: var(--spacing-xs);
+}
+
+#btn-validate::before {
+  content: '\f058';
   font-family: 'Font Awesome 6 Free';
   font-weight: 900;
   margin-right: var(--spacing-xs);

--- a/priv/static/css/layout.css
+++ b/priv/static/css/layout.css
@@ -792,8 +792,141 @@
   font-size: 0.6rem;
 }
 
+/* Content Layout Improvements */
+.description-content {
+  line-height: 1.7;
+  font-size: 0.875rem;
+  max-width: none; /* Remove any width restrictions */
+}
+
+/* Horizontal Controls Bar */
+.row.align-items-center.mb-3 {
+  padding-top: var(--spacing-sm);
+  margin-bottom: var(--spacing-lg) !important;
+  justify-content: space-between;
+}
+
+.row.align-items-center.mb-3 .col-auto:first-child {
+  margin-right: auto;
+}
+
+.row.align-items-center.mb-3 .col-auto:not(:first-child) {
+  margin-left: var(--spacing-md);
+}
+
+.row.align-items-center.mb-3 .col-auto:last-child {
+  margin-left: var(--spacing-md);
+}
+
+/* Button group styling in horizontal layout */
+.row .btn-group .btn {
+  font-size: 0.875rem;
+  padding: var(--spacing-xs) var(--spacing-sm);
+}
+
+/* Form controls in horizontal layout */
+.row .form-control {
+  min-width: 200px;
+}
+
+.row .selectpicker {
+  min-width: 180px;
+}
+
+/* Show deprecated container in horizontal layout */
+.row .show-deprecated-container {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  white-space: nowrap;
+}
+
+/* Mobile Responsive Layout */
+@media (max-width: 768px) {
+  .row.align-items-center.mb-3 {
+    flex-direction: column;
+    align-items: stretch !important;
+    gap: var(--spacing-sm);
+  }
+  
+  .row.align-items-center.mb-3 .col-auto {
+    margin-right: 0;
+    margin-bottom: var(--spacing-sm);
+  }
+  
+  .row.align-items-center.mb-3 .col-auto:last-child {
+    margin-bottom: 0;
+  }
+  
+  .row .btn-group {
+    display: flex;
+    justify-content: center;
+  }
+  
+  .row .form-control,
+  .row .selectpicker {
+    min-width: auto;
+    width: 100%;
+  }
+  
+  .row .show-deprecated-container {
+    justify-content: center;
+  }
+}
+
+/* Large Desktop Layout */
+@media (min-width: 1200px) {
+  .description-content {
+    font-size: 1rem;
+    line-height: 1.8;
+  }
+}
+
 /* Graph defaults */
 #network {
   width: 100%;
   height: 100vh;
+}
+
+/* Bootstrap Selectpicker Dropdown Positioning Fix */
+.bootstrap-select .dropdown-menu {
+  max-width: 300px;
+  overflow-x: auto;
+}
+
+/* Force dropdown to open to the left when near right edge */
+.fixed-right .bootstrap-select .dropdown-menu {
+  right: 0;
+  left: auto;
+  transform: translateX(0);
+}
+
+/* Ensure dropdown doesn't extend beyond viewport */
+.bootstrap-select.dropup .dropdown-menu,
+.bootstrap-select .dropdown-menu {
+  max-height: 350px;
+  overflow-y: auto;
+}
+
+/* Fix for selectpicker when positioned on the right side */
+.col-md-auto.fixed-right .bootstrap-select .dropdown-menu {
+  right: 0 !important;
+  left: auto !important;
+  min-width: 250px;
+  max-width: 300px;
+}
+
+/* Fix for selectpicker in horizontal controls bar (object/class pages) */
+.row.align-items-center .col-auto:last-child .bootstrap-select .dropdown-menu {
+  right: 0 !important;
+  left: auto !important;
+  min-width: 250px;
+  max-width: 300px;
+}
+
+/* General fix for any selectpicker near the right edge */
+.bootstrap-select:last-child .dropdown-menu,
+.col-auto:last-child .bootstrap-select .dropdown-menu {
+  right: 0 !important;
+  left: auto !important;
 }

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -29,7 +29,46 @@ function select_extensions(selected) {
   return '';
 }
 
+function build_url_params(extensions, profiles) {
+  let params = [];
+  
+  // Add extensions parameter
+  if (extensions) {
+    const extensionParams = [];
+    Object.entries(extensions).forEach(function ([name, value]) {
+      if (value) {
+        extensionParams.push(name);
+      }
+    });
+    if (extensionParams.length > 0) {
+      params.push('extensions=' + extensionParams.join(','));
+    }
+  }
+  
+  // Add profiles parameter
+  if (profiles && profiles.length > 0) {
+    params.push('profiles=' + profiles.join(','));
+  }
+  
+  return params.length > 0 ? '?' + params.join('&') : '';
+}
+
 function get_selected_extensions() {
+  // First check URL parameters, then fall back to localStorage
+  const urlParams = new URLSearchParams(window.location.search);
+  const extensionsParam = urlParams.get('extensions');
+  
+  if (extensionsParam !== null) {
+    const extensions = {};
+    if (extensionsParam !== '') {
+      const extensionList = extensionsParam.split(',').map(e => e.trim());
+      extensionList.forEach(extension => {
+        extensions[extension] = true;
+      });
+    }
+    return extensions;
+  }
+  
   return JSON.parse(localStorage.getItem('schema_extensions')) || {};
 }
 

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -284,27 +284,31 @@ const showDeprecatedStorageKey = "show-deprecated";
 function init_show_deprecated() {
   $(document).ready(function () {
     let checked = window.localStorage.getItem(showDeprecatedStorageKey);
-    if (checked == null || checked == "false") {
-      // Handling this case is needed in case where the prior state was checked _and_ local storage was
-      // cleared _and_ the user agent (browser) comes back to this page with the back button. The browser
-      // (at least Firefox) would keep the checkbox checked since that was the state of the UI.
-      document.getElementById("show-deprecated").checked = false;
-      // Initialize deprecated elements as hidden without animation
-      const deprecatedElements = document.querySelectorAll('.deprecated');
-      deprecatedElements.forEach(element => {
-        element.classList.add('deprecated-hidden');
-        // Ensure Bootstrap collapse state is also hidden
-        element.classList.remove('show');
-      });
-    } else if (checked == "true") {
-      document.getElementById("show-deprecated").checked = true;
-      // Initialize deprecated elements as visible without animation
-      const deprecatedElements = document.querySelectorAll('.deprecated');
-      deprecatedElements.forEach(element => {
-        element.classList.add('deprecated-visible');
-        // Ensure Bootstrap collapse state is also shown
-        element.classList.add('show');
-      });
+    const showDeprecatedCheckbox = document.getElementById("show-deprecated-global");
+    
+    if (showDeprecatedCheckbox) {
+      if (checked == null || checked == "false") {
+        // Handling this case is needed in case where the prior state was checked _and_ local storage was
+        // cleared _and_ the user agent (browser) comes back to this page with the back button. The browser
+        // (at least Firefox) would keep the checkbox checked since that was the state of the UI.
+        showDeprecatedCheckbox.checked = false;
+        // Initialize deprecated elements as hidden without animation
+        const deprecatedElements = document.querySelectorAll('.deprecated');
+        deprecatedElements.forEach(element => {
+          element.classList.add('deprecated-hidden');
+          // Ensure Bootstrap collapse state is also hidden
+          element.classList.remove('show');
+        });
+      } else if (checked == "true") {
+        showDeprecatedCheckbox.checked = true;
+        // Initialize deprecated elements as visible without animation
+        const deprecatedElements = document.querySelectorAll('.deprecated');
+        deprecatedElements.forEach(element => {
+          element.classList.add('deprecated-visible');
+          // Ensure Bootstrap collapse state is also shown
+          element.classList.add('show');
+        });
+      }
     }
     
     // Update container state

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -272,6 +272,11 @@ function init_schema_buttons() {
     const url = '/api' + window.location.pathname + "?profiles=" + get_selected_profiles().toString();
     window.open(url,'_blank');
   });
+
+  $('#btn-validate').on('click', function(event) {
+    const url = '/doc/index.html#/Tools/SchemaWeb.SchemaController.validate2';
+    window.open(url,'_blank');
+  });
 }
 
 const showDeprecatedStorageKey = "show-deprecated";

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -293,6 +293,8 @@ function init_show_deprecated() {
       const deprecatedElements = document.querySelectorAll('.deprecated');
       deprecatedElements.forEach(element => {
         element.classList.add('deprecated-hidden');
+        // Ensure Bootstrap collapse state is also hidden
+        element.classList.remove('show');
       });
     } else if (checked == "true") {
       document.getElementById("show-deprecated").checked = true;
@@ -300,11 +302,26 @@ function init_show_deprecated() {
       const deprecatedElements = document.querySelectorAll('.deprecated');
       deprecatedElements.forEach(element => {
         element.classList.add('deprecated-visible');
+        // Ensure Bootstrap collapse state is also shown
+        element.classList.add('show');
       });
     }
     
     // Update container state
     updateShowDeprecatedState(checked == "true");
+    
+    // Refresh the attribute display to show/hide deprecated rows based on stored state
+    const data = window.localStorage.getItem(selectedAttributesStorageKey);
+    let selected;
+    if (data == null) {
+      selected = selectedAttributesDefaultValues;
+    } else {
+      if (data.length > 0)
+        selected = data.split(",");
+      else
+        selected = [];
+    }
+    display_attributes(array_to_set(selected));
   });
 }
 

--- a/priv/static/js/profiles.js
+++ b/priv/static/js/profiles.js
@@ -9,11 +9,26 @@
 // limitations under the License.
 
 function get_selected_profiles() {
+  // First check URL parameters, then fall back to localStorage
+  const urlParams = new URLSearchParams(window.location.search);
+  const profilesParam = urlParams.get('profiles');
+  
+  if (profilesParam !== null) {
+    return profilesParam === '' ? [] : profilesParam.split(',').map(p => p.trim());
+  }
+  
   return JSON.parse(localStorage.getItem('schema_profiles')) || [];
 }
 
 function set_selected_profiles(profiles) {
   localStorage.setItem("schema_profiles", JSON.stringify(profiles));
+}
+
+function select_profiles(selected) {
+  if (selected && selected.length > 0) {
+    return '&profiles=' + selected.join(',');
+  }
+  return '';
 }
 
 function init_selected_profiles(profiles) {
@@ -56,8 +71,13 @@ function init_class_profiles() {
     });
 
     set_selected_profiles(selected_profiles);
-    init_selected_profiles(selected_profiles);
-    refresh_selected_profiles();
+    
+    // Update URL with both extensions and profiles using the unified function
+    const selected_extensions = get_selected_extensions();
+    const params = build_url_params(selected_extensions, selected_profiles);
+    
+    // Update the URL
+    window.location.search = params;
   });
 }
 


### PR DESCRIPTION
Key Items in this PR:
1. Bug fix for #162. 
2. Layout improvements -
   1. A new global control for deprecated items on the side bar:
        1. <img width="232" height="119" alt="Screenshot 2025-08-26 at 10 19 33" src="https://github.com/user-attachments/assets/fa23c879-65aa-4ec7-a256-b2733936947f" />
   2. A more consistent layout for all the control buttons on class and object pages. A new `validate` button, to surface the validation API. Description now uses full page width instead of a restricted column
         1. <img width="1384" height="288" alt="Screenshot 2025-08-26 at 10 20 14" src="https://github.com/user-attachments/assets/f283f335-35e0-483c-ad3b-987a82af3e88" />
4. Perhaps my favorite addition, now you can hard-link to a specific class+extension+profile combo and share easily with others., without having to ask them to select x extension and y profiles from the side bar after sharing a class link.
         1. <img width="781" height="31" alt="Screenshot 2025-08-26 at 10 24 32" src="https://github.com/user-attachments/assets/32a5f1b2-95c6-4410-8429-2e664396d565" />
         2. <img width="932" height="595" alt="Screenshot 2025-08-26 at 10 24 44" src="https://github.com/user-attachments/assets/6bbd6b3b-9d63-4739-8b59-85c8d85b848b" />

4. Bumping the minor version of the server build

As always, I would suggest pulling the PR down to fully experience these changes