### PR TITLE
[Bug Fix] Adding group selection options for "profile" page

### DIFF
--- a/lib/schema_web/templates/page/profile.html.eex
+++ b/lib/schema_web/templates/page/profile.html.eex
@@ -32,6 +32,12 @@
   <div class="col"></div>
   <div class="col-auto">
     <select multiple id="attributes-select" class="selectpicker" data-style="btn-outline-secondary" data-selected-text-format="count > 3" data-actions-box="true" data-width="auto">
+      <optgroup id="groups-select" label="Groups">
+        <option selected value="classification">Classification</option>
+        <option selected value="context">Context</option>
+        <option selected value="occurrence">Occurrence</option>
+        <option selected value="primary">Primary</option>
+      </optgroup>
       <optgroup id="requirements-select" label="Requirements">
         <option class="optional" value="optional" title="Optional">Optional Attributes</option>
         <option class="recommended" value="recommended" title="Recommended">Recommended Attributes</option>

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "3.1.0"
+  @version "3.1.1"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"


### PR DESCRIPTION
Selectors maintain a shared state for all pages in the schema browser. The selector in the profile page, didn't have group selection options, leading to degraded ux, when people deselected groups in the classes page and navigated to the profile page without any options to re-select groups. See the screenshots for reference.
 
This PR fixes that flow. Now the profile page also allows users to select/de-select groups.

Current flow:

De-selecting everything on a class page
<img width="1309" height="642" alt="Screenshot 2025-10-07 at 11 21 48" src="https://github.com/user-attachments/assets/ffafdbab-7023-4ae8-9a8c-de85df02c539" />

Then, navigating to the profile page. Observe there are no options to select groups.
<img width="1329" height="397" alt="Screenshot 2025-10-07 at 11 22 30" src="https://github.com/user-attachments/assets/9277b6f8-56da-4761-bae2-d8668e32dc4f" />


After the fix:

<img width="1322" height="528" alt="Screenshot 2025-10-07 at 11 23 27" src="https://github.com/user-attachments/assets/30e6d1ff-1b2b-49b5-8e74-6890cfc1b2e9" />