### PR TITLE
[Dockerfile] Adding package update steps to build and runtime stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,11 @@ FROM ${elixir_image} AS builder
 # prepare build dir
 WORKDIR /app
 
-RUN apk --update add openssl
+# Install updates and required packages
+RUN apk update && \
+    apk upgrade --no-cache && \
+    apk add --no-cache openssl && \
+    rm -rf /var/cache/apk/*
 
 # install hex + rebar
 RUN mix local.hex --force && \
@@ -50,6 +54,11 @@ RUN mix release
 # start a new build stage so that the final image will only contain
 # the compiled release and other runtime necessities
 FROM ${elixir_image}
+
+# Install updates in runtime stage
+RUN apk update && \
+    apk upgrade --no-cache && \
+    rm -rf /var/cache/apk/*
 
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en


### PR DESCRIPTION
#### Builder Stage Improvements

  - Added `apk upgrade --no-cache` to apply patches to existing packages
  - Modified `openssl` installation to use `--no-cache` flag to avoid storing package cache
  - Added explicit cache cleanup with `rm -rf /var/cache/apk/*` to reduce image size

#### Runtime Stage Improvements

  - Ensures the final runtime image has the latest patches
  - Removes apk cache to minimize final image size
