### PR TITLE
[bugfix] url generation for js buttons (json schema & sample)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "4.0.0"
+  @version "4.0.1"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -258,24 +258,31 @@ function searchInCategories(filter) {
 }
 
 function init_schema_buttons() {
+  // Strip any version prefix (e.g. /1.3.0) from the pathname so the
+  // /sample, /schema, and /api routes resolve correctly when the server
+  // is fronted by a versioned URL prefix.
+  const basePath = window.location.pathname.replace(/^\/[\d.]+(?:-[^\/]+)?/, '');
+
+  function buttonParams() {
+    const extensions = get_selected_extensions();
+    const profiles = get_selected_profiles();
+    return build_url_params(extensions, profiles);
+  }
+
   $('#btn-sample-data').on('click', function(event) {
-    const url = '/sample' + window.location.pathname + "?profiles=" + get_selected_profiles().toString();
-    window.open(url,'_blank');
+    window.open('/sample' + basePath + buttonParams(), '_blank');
   });
 
   $('#btn-json-schema').on('click', function(event) {
-    const url = '/schema' + window.location.pathname + "?profiles=" + get_selected_profiles().toString();
-    window.open(url,'_blank');
+    window.open('/schema' + basePath + buttonParams(), '_blank');
   });
 
   $('#btn-schema').on('click', function(event) {
-    const url = '/api' + window.location.pathname + "?profiles=" + get_selected_profiles().toString();
-    window.open(url,'_blank');
+    window.open('/api' + basePath + buttonParams(), '_blank');
   });
 
   $('#btn-validate').on('click', function(event) {
-    const url = '/doc/index.html#/Tools/SchemaWeb.SchemaController.validate2';
-    window.open(url,'_blank');
+    window.open('/doc/index.html#/Tools/SchemaWeb.SchemaController.validate2', '_blank');
   });
 }
 


### PR DESCRIPTION
Fixed two issues in init_schema_buttons(): (particularly matters for multi-version setups)

1. The version prefix (e.g. 1.3.0) in window.location.pathname wasn't being stripped, so buttons would generate broken URLs like /sample/1.3.0/classes/dns_activity that don't match any route. Now uses the same regex the nav link code already uses.
2. Only ?profiles= was being passed as a query param — selected extensions were silently dropped. Now uses build_url_params() (which already existed in the codebase) to forward both extensions and profiles.