### PR TITLE
Support for references view on the profile page

### DIFF
--- a/lib/schema_web/templates/page/profile.html.eex
+++ b/lib/schema_web/templates/page/profile.html.eex
@@ -25,6 +25,7 @@ limitations under the License.
     <div class="text-secondary description-content">
       <%= raw @data[:description] %>
     </div>
+    <%= raw object_references_section(@data[:references]) %>
   </div>
   <div class="navbar-nav col-md-auto fixed-right mt-2">
     <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "4.0.1"
+  @version "4.0.2"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"


### PR DESCRIPTION
Profiles in the OCSF schema can define a references field (e.g. the datetime profile links to RFC-3339), but the profile detail page never rendered them. The object detail page already has this — this PR reuses the same object_references_section/1 helper to show references on profile pages too.

#### Changes

* profile.html.eex — added object_references_section(@data[:references]) below the description, matching the object page layout
* mix.exs — version bump to 4.0.2
The helper already handles nil/empty references gracefully, so profiles without references are unaffected.

#### Testing

Verified profiles with references (e.g. datetime) display the References section with clickable links | https://github.com/ocsf/ocsf-schema/pull/1616
Verified profiles without references render unchanged