### PR TITLE
Added deprecation markers for class, object and profile page | Also includes bugfix for extension attribute selections

### DIFF
--- a/lib/schema_web/controllers/page_controller.ex
+++ b/lib/schema_web/controllers/page_controller.ex
@@ -32,6 +32,8 @@ defmodule SchemaWeb.PageController do
 
   @spec category_by_id(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def category_by_id(conn, params) do
+    params = Map.put_new(params, "extensions", "")
+
     case SchemaController.category_classes(params) do
       nil ->
         send_resp(conn, 404, "Not Found: #{SchemaController.params_to_uid(params)}")
@@ -49,6 +51,7 @@ defmodule SchemaWeb.PageController do
 
   @spec profiles(Plug.Conn.t(), map) :: Plug.Conn.t()
   def profiles(conn, params) do
+    params = Map.put_new(params, "extensions", "")
     profiles = get_profiles(params)
     sorted_profiles = sort_by_descoped_key(profiles)
 
@@ -81,7 +84,10 @@ defmodule SchemaWeb.PageController do
 
   @spec classes(Plug.Conn.t(), any) :: Plug.Conn.t()
   def classes(conn, params) do
-    data = SchemaController.classes(params) |> sort_by(:uid)
+    data =
+      Map.put_new(params, "extensions", "")
+      |> SchemaController.classes()
+      |> sort_by(:uid)
 
     render(conn, "classes.html",
       extensions: Schema.extensions(),
@@ -137,6 +143,8 @@ defmodule SchemaWeb.PageController do
 
   @spec objects(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def objects(conn, params) do
+    params = Map.put_new(params, "extensions", "")
+
     data =
       SchemaController.parse_options(SchemaController.extensions(params))
       |> Schema.objects_filter_extensions()
@@ -190,6 +198,7 @@ defmodule SchemaWeb.PageController do
 
   @spec dictionary(Plug.Conn.t(), any) :: Plug.Conn.t()
   def dictionary(conn, params) do
+    params = Map.put_new(params, "extensions", "")
     schema = Schema.schema()
 
     data =

--- a/lib/schema_web/templates/layout/app.html.eex
+++ b/lib/schema_web/templates/layout/app.html.eex
@@ -46,9 +46,24 @@ limitations under the License.
           this.href = this.href + params;
         });
 
-        // Also update main navigation links
+        // Also update main navigation links (skip dropdown toggles and hash-only links)
         $(".top-navbar-nav a.nav-link").each(function() {
+          if (this.getAttribute('href') === '#' || this.classList.contains('dropdown-toggle')) {
+            return;
+          }
           this.href = this.href + params;
+        });
+
+        // Update content links (class, object, category, profile links in page body)
+        $(".main-page a").each(function() {
+          const href = this.getAttribute('href');
+          if (!href || href.startsWith('http') || href.startsWith('#') || href.startsWith('javascript:') || href.includes('?')) {
+            return;
+          }
+          // Only update internal schema navigation links
+          if (href.match(/^\/(classes|objects|categories|profiles|dictionary|data_types)/)) {
+            this.href = this.href + params;
+          }
         });
 
         // set the profile checkboxes
@@ -267,7 +282,7 @@ limitations under the License.
       <div class="navbar-text">|</div>
 
       <li id="resources_id" class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="#" role="button">Resources</a>
+        <a class="nav-link dropdown-toggle" href="javascript:void(0)" role="button">Resources</a>
         <div class="dropdown-content">
           <a class="dropdown-link" target="_blank" href='<%= Routes.static_path(@conn, "/doc") %>'>API Documentation</a>
           <a class="dropdown-link" target="_blank" href="https://github.com/ocsf/ocsf-docs/blob/main/overview/understanding-ocsf.md">Understanding OCSF</a>

--- a/lib/schema_web/templates/layout/app.html.eex
+++ b/lib/schema_web/templates/layout/app.html.eex
@@ -95,6 +95,9 @@ limitations under the License.
         case '/objects':
           $('#objects_id a.nav-link').addClass("active");
           break;
+        case '/profiles':
+          $('#profiles_id a.nav-link').addClass("active");
+          break;
         case '/objects/observable':
           $('#observable_id a.nav-link').addClass("active");
           break;
@@ -247,6 +250,9 @@ limitations under the License.
       </li>
       <li id="objects_id" class="nav-item">
         <a class="nav-link" href='<%= Routes.static_path(@conn, "/objects") %>'>Objects</a>
+      </li>
+      <li id="profiles_id" class="nav-item">
+        <a class="nav-link" href='<%= Routes.static_path(@conn, "/profiles") %>'>Profiles</a>
       </li>
       <li id="observable_id" class="nav-item">
         <a class="nav-link" href='<%= Routes.static_path(@conn, "/objects/observable") %>'>Observable</a>

--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -51,6 +51,16 @@ limitations under the License.
     <div class="text-secondary description-content">
       <%= raw description(@data) %>
     </div>
+    <%= if has_deprecated_attributes?(@data) do %>
+    <% dep_count = deprecated_attributes_count(@data) %>
+    <div class="deprecated-attr-notice" id="deprecated-attr-notice">
+      <i class="fas fa-exclamation-triangle"></i>
+      <span>
+        This class contains <strong><%= dep_count %></strong> deprecated <%= if dep_count == 1, do: "attribute", else: "attributes" %>.
+        Check the <strong>Show deprecated items</strong> box in the sidebar to view <%= if dep_count == 1, do: "it", else: "them" %>.
+      </span>
+    </div>
+    <% end %>
     <%= if observables != nil and !Enum.empty?(observables) do %>
     <div class="text-secondary mt-2">
       Class-specific attribute path observables are <a href="#observables">at the bottom of this page</a>.

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -46,6 +46,16 @@ limitations under the License.
     <div class="text-secondary description-content">
       <%= raw description(@data) %>
     </div>
+    <%= if has_deprecated_attributes?(@data) do %>
+    <% dep_count = deprecated_attributes_count(@data) %>
+    <div class="deprecated-attr-notice" id="deprecated-attr-notice">
+      <i class="fas fa-exclamation-triangle"></i>
+      <span>
+        This object contains <strong><%= dep_count %></strong> deprecated <%= if dep_count == 1, do: "attribute", else: "attributes" %>.
+        Check the <strong>Show deprecated items</strong> box in the sidebar to view <%= if dep_count == 1, do: "it", else: "them" %>.
+      </span>
+    </div>
+    <% end %>
     <%= raw object_references_section(references) %>
   </div>
   <div class="navbar-nav col-md-auto fixed-right mt-2">

--- a/lib/schema_web/templates/page/profile.html.eex
+++ b/lib/schema_web/templates/page/profile.html.eex
@@ -25,6 +25,16 @@ limitations under the License.
     <div class="text-secondary description-content">
       <%= raw @data[:description] %>
     </div>
+    <%= if has_deprecated_attributes?(@data) do %>
+    <% dep_count = deprecated_attributes_count(@data) %>
+    <div class="deprecated-attr-notice" id="deprecated-attr-notice">
+      <i class="fas fa-exclamation-triangle"></i>
+      <span>
+        This profile contains <strong><%= dep_count %></strong> deprecated <%= if dep_count == 1, do: "attribute", else: "attributes" %>.
+        Check the <strong>Show deprecated items</strong> box in the sidebar to view <%= if dep_count == 1, do: "it", else: "them" %>.
+      </span>
+    </div>
+    <% end %>
     <%= raw object_references_section(@data[:references]) %>
   </div>
   <div class="navbar-nav col-md-auto fixed-right mt-2">

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -1743,4 +1743,36 @@ defmodule SchemaWeb.PageView do
   def show_deprecated_css_classes(item) do
     show_deprecated_css_classes(item, "")
   end
+
+  @doc """
+  Returns true if the item (class or object) contains at least one deprecated attribute.
+  """
+  @spec has_deprecated_attributes?(map()) :: boolean()
+  def has_deprecated_attributes?(item) do
+    deprecated_attributes_count(item) > 0
+  end
+
+  @doc """
+  Returns the count of deprecated attributes in the item (class or object).
+  """
+  @spec deprecated_attributes_count(map()) :: non_neg_integer()
+  def deprecated_attributes_count(item) do
+    case item[:attributes] do
+      nil ->
+        0
+
+      attributes when is_map(attributes) ->
+        Enum.count(attributes, fn {_key, attr} ->
+          attr[:"@deprecated"] != nil
+        end)
+
+      attributes when is_list(attributes) ->
+        Enum.count(attributes, fn {_key, attr} ->
+          attr[:"@deprecated"] != nil
+        end)
+
+      _ ->
+        0
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "4.0.2"
+  @version "4.1.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/priv/static/css/components.css
+++ b/priv/static/css/components.css
@@ -764,3 +764,56 @@ button:hover,
   background: var(--surface-color);
   border-left-color: var(--accent-color);
 }
+
+/* Deprecated Attributes Badge - shown on classes/objects that contain deprecated attributes */
+.deprecated-attr-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--warning-color);
+  font-size: 0.75rem;
+  cursor: help;
+  opacity: 0.85;
+  transition: var(--transition-fast);
+}
+
+.deprecated-attr-badge:hover {
+  opacity: 1;
+  transform: scale(1.15);
+}
+
+[data-theme="dark"] .deprecated-attr-badge {
+  color: #FBBF24;
+}
+
+/* Deprecated Attributes Notice - banner on class/object detail pages */
+.deprecated-attr-notice {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  background: rgba(217, 119, 6, 0.08);
+  border: 1px solid rgba(217, 119, 6, 0.3);
+  border-left: 3px solid var(--warning-color);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin-top: var(--spacing-md);
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  width: fit-content;
+}
+
+.deprecated-attr-notice i {
+  color: var(--warning-color);
+  font-size: 0.875rem;
+  flex-shrink: 0;
+}
+
+[data-theme="dark"] .deprecated-attr-notice {
+  background: rgba(251, 191, 36, 0.08);
+  border-color: rgba(251, 191, 36, 0.3);
+  border-left-color: #FBBF24;
+}
+
+[data-theme="dark"] .deprecated-attr-notice i {
+  color: #FBBF24;
+}

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -32,7 +32,7 @@ function select_extensions(selected) {
 function build_url_params(extensions, profiles) {
   let params = [];
   
-  // Add extensions parameter
+  // Always add extensions parameter (empty string means core-only)
   if (extensions) {
     const extensionParams = [];
     Object.entries(extensions).forEach(function ([name, value]) {
@@ -40,9 +40,9 @@ function build_url_params(extensions, profiles) {
         extensionParams.push(name);
       }
     });
-    if (extensionParams.length > 0) {
-      params.push('extensions=' + extensionParams.join(','));
-    }
+    params.push('extensions=' + extensionParams.join(','));
+  } else {
+    params.push('extensions=');
   }
   
   // Add profiles parameter


### PR DESCRIPTION

1. Deprecated attributes notice on detail pages
* Added has_deprecated_attributes?/1 and deprecated_attributes_count/1 helpers to page_view.ex
* Class, object, and profile detail pages now show a notice banner when they contain deprecated attributes, with the count and a prompt to check "Show deprecated items"

<img width="1232" height="436" alt="image" src="https://github.com/user-attachments/assets/667199bc-cb9c-4ecc-8ff2-816eddfaf6f4" />


---

2. Profiles link in top navigation
* Added "Profiles" nav item between "Objects" and "Observable" in the top header bar

3. Extension filtering fix
* JS (app.js): build_url_params now always includes extensions= in the URL, even when empty, so the server can distinguish "no extensions selected" from "param not provided"
* Server (page_controller.ex): All page actions (classes, objects, dictionary, profiles, category_by_id) now default extensions to "" when the param is missing, ensuring core-only filtering on direct page loads

4. Extension params retained on content navigation
* Content links in .main-page (class, object, category, profile, dictionary paths) now get extension/profile params appended on page load, so navigating into a class/object preserves the selected extensions in the URL
