### PR TITLE
Bug fix #181 and #182 

### DIFF
--- a/lib/schema/utils.ex
+++ b/lib/schema/utils.ex
@@ -203,6 +203,12 @@ defmodule Schema.Utils do
   end
 
   @spec filter_attributes_by_profiles_set(Enum.t(), string_set_t()) :: Enum.t()
+  defp filter_attributes_by_profiles_set(attributes, profiles) when is_map(attributes) do
+    Map.filter(attributes, fn {_k, a} ->
+      a[:profiles] == nil || Enum.any?(a[:profiles], fn ap -> MapSet.member?(profiles, ap) end)
+    end)
+  end
+
   defp filter_attributes_by_profiles_set(attributes, profiles) do
     Enum.filter(attributes, fn {_k, a} ->
       a[:profiles] == nil || Enum.any?(a[:profiles], fn ap -> MapSet.member?(profiles, ap) end)

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -833,18 +833,10 @@ defmodule SchemaWeb.PageView do
     source = obj[:source]
     references = obj[:references]
 
-    source_html =
-      if source != nil do
-        # source can have embedded markup
-        ["<dt>Source<dd class=\"ml-3\">", source]
-      else
-        ""
-      end
+    refs_html = inline_references(references, source)
 
-    refs_html = inline_references(references)
-
-    if source_html != "" or refs_html != "" do
-      [html, prefix_html, "<dd>", source_html, refs_html, "</dd>"]
+    if refs_html != "" do
+      [html, prefix_html, refs_html]
     else
       html
     end
@@ -1718,17 +1710,28 @@ defmodule SchemaWeb.PageView do
 
   def object_references_section(_), do: ""
 
-  @spec inline_references(list()) :: any()
-  def inline_references(references) when is_list(references) and length(references) > 0 do
+  @spec inline_references(list(), String.t() | nil) :: any()
+  def inline_references(references, source \\ nil)
+
+  def inline_references(references, source)
+      when is_list(references) and length(references) > 0 do
+    source_html =
+      if source != nil do
+        [" <span class=\"references-source\">(as <code>", source, "</code>)</span>"]
+      else
+        ""
+      end
+
     [
       "<div class=\"references-inline\">",
       "<span class=\"references-label\">Refs:</span>",
       Enum.intersperse(Enum.map(references, &reference_tag/1), " "),
+      source_html,
       "</div>"
     ]
   end
 
-  def inline_references(_), do: ""
+  def inline_references(_, _), do: ""
 
   @spec show_deprecated_css_classes(map(), String.t()) :: String.t()
   def show_deprecated_css_classes(item, initial) do

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "4.1.0"
+  @version "4.1.1"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "4.1.1"
+  @version "4.2.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/priv/static/css/components.css
+++ b/priv/static/css/components.css
@@ -680,6 +680,12 @@ button:hover,
   margin-right: var(--spacing-xs);
 }
 
+.references-inline .references-source {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-left: var(--spacing-xs);
+}
+
 .reference-tag {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- Fix 500 Internal Server Error on `/api/classes/:id?profiles=...` endpoints (fixes #182)
- Fix inconsistent rendering of the `source` meta schema attribute to match `references` style (fixes #181)

## Details

### Profile filtering crash (#182)

`filter_attributes_by_profiles_set/2` in `utils.ex` used `Enum.filter/2` on a map of attributes. In Elixir, `Enum.filter` on a map returns a list of `{key, value}` tuples — not a map. When passed to `Jason.encode!/2`, it raised `Protocol.UndefinedError` because Jason cannot encode tuples.

Added a `when is_map(attributes)` clause that uses `Map.filter/2` to preserve the map structure.

### Source attribute rendering (#181)

The `source` meta schema attribute was rendered as a bold `<dt>` definition term on its own line, while `references` rendered as a subdued inline element. Since `source` indicates the original field name in the standard referenced by `references`, it now renders inline after the reference tags:

> **Refs:** [RFC 5322](…) (as `Message-ID`)

Changed `inline_references/1` to accept an optional `source` parameter and append it as `(as <code>source</code>)` in a muted style consistent with the refs label.

## Test plan

- [x] `GET /api/classes/account_change?profiles=host` → 200 with filtered attributes
- [x] `GET /api/classes/account_change?profiles=%22host%22` → 200
- [x] `GET /api/classes/account_change?profiles=%5B%22host%22%5D` → 200
- [x] `GET /api/classes/file_activity?profiles=cloud` → 200
- [x] `GET /api/classes/account_change` (no profile) → 200, unchanged behavior
- [x] All 12 `source` occurrences render inline with refs (verified: `detection_finding.impact_id`, `email.message_uid`, `network_connection_info.community_uid`, `process_entity.cpid`)
- [x] Pages without `source` render refs unchanged
- [x] `mix compile` passes cleanly
