### PR TITLE
Add a set of V2 JSON Schema endpoints.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.ex]
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/config/config.exs
+++ b/config/config.exs
@@ -33,6 +33,16 @@ config :phoenix_swagger, json_library: Jason
 config :schema_server, Schema.Application, schema_file: System.get_env("SCHEMA_FILE")
 config :schema_server, Schema.Application, schemas_home: System.get_env("SCHEMAS_HOME")
 
+config :schema_server, :json_formats,
+  datetime_t: "date-time",
+  ip_t: "ipv6",
+  email_t: "email",
+  hostname_t: "hostname",
+  url_t: "uri",
+  uuid_t: "uuid"
+
+config :schema_server, :json_java_names, class: "objectClass"
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/lib/schema/json_schema.ex
+++ b/lib/schema/json_schema.ex
@@ -12,7 +12,7 @@ defmodule Schema.JsonSchema do
   Json schema generator. This module defines functions that generate JSON schema (see http://json-schema.org) schemas for OCSF schema.
   """
   @schema_base_uri "https://schema.ocsf.io/schema/classes"
-  @schema_version "http://json-schema.org/draft-07/schema#"
+  @schema_version "http://json-schema.org/draft-07/schema"
 
   @doc """
   Generates a JSON schema corresponding to the `type` parameter.
@@ -33,6 +33,10 @@ defmodule Schema.JsonSchema do
     end
   end
 
+  def encode(nil, _) do
+    %{}
+  end
+
   @spec encode_item(map(), map()) :: map()
   defp encode_item(item, data_types) do
     name = item[:name]
@@ -44,6 +48,7 @@ defmodule Schema.JsonSchema do
     else
       Map.new()
       |> add_java_class(name)
+      |> add_object_id(name)
     end
     |> Map.put("title", item[:caption])
     |> Map.put("type", "object")
@@ -54,6 +59,17 @@ defmodule Schema.JsonSchema do
     |> put_at_least_one(at_least_one)
     |> encode_objects(item[:objects], data_types)
     |> empty_object(properties)
+  end
+
+  defp add_object_id(obj, name) do
+    ref_base =
+      Process.get(:options, [])
+      |> Keyword.get(:ref_base)
+
+    case ref_base do
+      nil -> obj
+      _ -> obj |> Map.put("$id", make_object_ref(name)) |> Map.put("$schema", @schema_version)
+    end
   end
 
   defp add_java_class(obj, name) do
@@ -88,15 +104,27 @@ defmodule Schema.JsonSchema do
   end
 
   defp make_object_ref(name) do
-    Path.join([ref_object(), String.replace(name, "/", "_")])
-  end
+    base =
+      Process.get(:options, [])
+      |> Keyword.get(:ref_base, "#/$defs")
 
-  defp ref_object() do
-    "#/$defs"
+    endpoint =
+      Process.get(:options, [])
+      |> Keyword.get(:ref_endpoint_objects, "")
+
+    Path.join([base, endpoint, String.replace(name, "/", "_")])
   end
 
   defp make_class_ref(name) do
-    Path.join([@schema_base_uri, name])
+    base =
+      Process.get(:options, [])
+      |> Keyword.get(:ref_base, @schema_base_uri)
+
+    endpoint =
+      Process.get(:options, [])
+      |> Keyword.get(:ref_endpoint_classes, "")
+
+    Path.join([base, endpoint, name])
   end
 
   defp empty_object(map, properties) do
@@ -155,13 +183,20 @@ defmodule Schema.JsonSchema do
   end
 
   defp encode_objects(schema, objects, data_types) do
+    ref_base =
+      Process.get(:options, [])
+      |> Keyword.get(:ref_base)
+
     defs =
       Enum.into(objects, %{}, fn {name, object} ->
         key = Atom.to_string(name) |> String.replace("/", "_")
         {key, encode_item(object, data_types)}
       end)
 
-    Map.put(schema, "$defs", defs)
+    case ref_base do
+      nil -> Map.put(schema, "$defs", defs)
+      _ -> schema
+    end
   end
 
   defp map_reduce(type_name, type, data_types) do
@@ -190,7 +225,9 @@ defmodule Schema.JsonSchema do
           |> (fn {required, just_one, at_least_one} ->
                 schema =
                   encode_attribute(type_name, attribute[:type], attribute, data_types)
+                  |> encode_format(attribute[:type])
                   |> encode_array(attribute[:is_array])
+                  |> encode_java_names(name)
 
                 {{name, schema}, {required, just_one, at_least_one}}
               end).()
@@ -279,6 +316,38 @@ defmodule Schema.JsonSchema do
     {type, schema} = items_type(schema)
 
     Map.put(schema, "type", "array") |> Map.put("items", type)
+  end
+
+  defp encode_format(schema, type) do
+    include_formats =
+      Process.get(:options, [])
+      |> Keyword.get(:include_formats)
+
+    format =
+      Application.get_env(:schema_server, :json_formats)
+      |> Keyword.get(String.to_atom(type))
+
+    cond do
+      include_formats == nil -> schema
+      format == nil -> schema
+      true -> Map.put(schema, "format", format)
+    end
+  end
+
+  defp encode_java_names(schema, name) do
+    include_java_names =
+      Process.get(:options, [])
+      |> Keyword.get(:include_java_names)
+
+    java_name =
+      Application.get_env(:schema_server, :json_java_names)
+      |> Keyword.get(String.to_atom(name))
+
+    cond do
+      include_java_names == nil -> schema
+      java_name == nil -> schema
+      true -> Map.put(schema, "javaName", java_name)
+    end
   end
 
   defp encode_array(schema, _is_array) do

--- a/lib/schema_web/controllers/class_schema_controller.ex
+++ b/lib/schema_web/controllers/class_schema_controller.ex
@@ -1,0 +1,59 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+defmodule SchemaWeb.ClassSchemaController do
+  @moduledoc """
+  The controller which generates JSON schemas for OCSF Classes.
+  """
+
+  use SchemaWeb, :controller
+  import PhoenixSwagger
+
+  swagger_path :show do
+    get("/api/v2/classes/{name}")
+
+    tag("JSON Schema")
+    summary("Describe an OCSF Class as a JSON Schema")
+
+    description("""
+    Return a description of the given OCSF class as a Draft 07 JSON Schema.
+    """)
+
+    parameters do
+      name(:name, :string, "Object Name", required: true)
+    end
+
+    produces("application/json")
+
+    response(200, "Success")
+    response(404, "Not Found")
+  end
+
+  @spec show(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def show(conn, %{"id" => object_name}) do
+    options = [
+      ref_base: SchemaWeb.Endpoint.url(),
+      ref_endpoint_objects: "/api/v2/objects",
+      ref_endpoint_classes: "/api/v2/classes",
+      include_formats: true,
+      include_java_names: true
+    ]
+
+    object =
+      object_name
+      |> String.to_atom()
+      |> Schema.class_with_referenced_objects_filter_profiles(nil)
+      |> Schema.JsonSchema.encode(options)
+
+    case object do
+      result when map_size(result) == 0 -> send_resp(conn, :not_found, "")
+      result -> json(conn, object)
+    end
+  end
+end

--- a/lib/schema_web/controllers/object_schema_controller.ex
+++ b/lib/schema_web/controllers/object_schema_controller.ex
@@ -1,0 +1,58 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+defmodule SchemaWeb.ObjectSchemaController do
+  @moduledoc """
+  The controller which generates JSON schemas for OCSF Objects.
+  """
+
+  use SchemaWeb, :controller
+  import PhoenixSwagger
+
+  swagger_path :show do
+    get("/api/v2/objects/{name}")
+
+    tag("JSON Schema")
+    summary("Describe an OCSF Object as a JSON Schema")
+
+    description("""
+    Return a description of the given OCSF object as a Draft 07 JSON Schema.
+    """)
+
+    parameters do
+      name(:name, :string, "Object Name", required: true)
+    end
+
+    produces("application/json")
+
+    response(200, "Success")
+    response(404, "Not Found")
+  end
+
+  @spec show(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def show(conn, %{"id" => object_name}) do
+    options = [
+      ref_base: SchemaWeb.Endpoint.url(),
+      ref_endpoint_objects: "/api/v2/objects",
+      include_formats: true,
+      include_java_names: true
+    ]
+
+    object =
+      object_name
+      |> String.to_atom()
+      |> Schema.clean_object_filter_extensions_profiles(nil, nil)
+      |> Schema.JsonSchema.encode(options)
+
+    case object do
+      result when map_size(result) == 0 -> send_resp(conn, :not_found, "")
+      result -> json(conn, result)
+    end
+  end
+end

--- a/lib/schema_web/controllers/page_controller.ex
+++ b/lib/schema_web/controllers/page_controller.ex
@@ -116,7 +116,6 @@ defmodule SchemaWeb.PageController do
     end
   end
 
-
   @doc """
   Redirects from the older /base_event URL to /classes/base_event.
   """
@@ -163,7 +162,6 @@ defmodule SchemaWeb.PageController do
     end
   end
 
-
   @spec dictionary(Plug.Conn.t(), any) :: Plug.Conn.t()
   def dictionary(conn, params) do
     params = Map.put_new(params, "extensions", "")
@@ -203,6 +201,7 @@ defmodule SchemaWeb.PageController do
     cond do
       params["class"] ->
         id = String.to_atom(params["class"])
+
         case Schema.class_filter_profiles(schema, id, profiles) do
           nil ->
             send_resp(conn, 404, "Not Found: #{params["class"]}")
@@ -217,6 +216,7 @@ defmodule SchemaWeb.PageController do
 
       params["object"] ->
         id = String.to_atom(params["object"])
+
         case Schema.object_filter_extensions_profiles(schema, id, extensions, profiles) do
           nil ->
             send_resp(conn, 404, "Not Found: #{params["object"]}")
@@ -231,12 +231,14 @@ defmodule SchemaWeb.PageController do
 
       params["category"] ->
         id = String.to_atom(params["category"])
+
         case Schema.SingleRepo.categories()[:attributes][id] do
           nil ->
             send_resp(conn, 404, "Not Found: #{params["category"]}")
 
           cat ->
-            scope_data = cat
+            scope_data =
+              cat
               |> Map.put(:scope_type, :category)
               |> Map.put_new(:name, params["category"])
 

--- a/lib/schema_web/router.ex
+++ b/lib/schema_web/router.ex
@@ -38,13 +38,11 @@ defmodule SchemaWeb.Router do
     get "/classes/:id", PageController, :class_by_id
     get "/classes/:extension/:id", PageController, :class_by_id
 
-
     get "/base_event", PageController, :base_event
 
     get "/objects", PageController, :objects
     get "/objects/:id", PageController, :object_by_id
     get "/objects/:extension/:id", PageController, :object_by_id
-
 
     get "/dictionary", PageController, :dictionary
     get "/data_types", PageController, :data_types
@@ -54,6 +52,11 @@ defmodule SchemaWeb.Router do
   # Other scopes may use custom stacks.
   scope "/api", SchemaWeb do
     pipe_through :api
+
+    scope "/v2" do
+      resources "/objects", ObjectSchemaController, only: [:show]
+      resources "/classes", ClassSchemaController, only: [:show]
+    end
 
     get "/version", SchemaController, :version
     get "/versions", SchemaController, :versions

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -8,7 +8,6 @@ defmodule SchemaWeb.PageView do
   @unknown_constraint_symbol "*"
   @enum_attributes_doc_url "https://github.com/ocsf/ocsf-docs/blob/main/overview/understanding-ocsf.md#enum-attributes"
 
-
   def class_path(conn, data) do
     class_name = data[:name]
 
@@ -20,7 +19,6 @@ defmodule SchemaWeb.PageView do
         Routes.static_path(conn, "/classes/" <> extension <> "/" <> class_name)
     end
   end
-
 
   def object_path(conn, data) do
     object_name = data[:name]


### PR DESCRIPTION
These attempt to bring our generated schemas more "in line" with draft-07, and provide some additional assistance when generating OCSF models from these schemas.

Specifically this addresses:
1. All generated schemas, for both classes and objects have non-relative base URIs for $ref and $id fields. This attempts to provide the widest compatibility across generation tooling, and ensure that URL based resolution is functional with a local copy of the schema.
2. OCSF attribute names which break generation (e.g. "class" in Java) are aliased in such a fashion to not cause compiler errors.
3. In situations where a built-in JSON schema format is compatible with the OCSF definition of a logical type, we provide the format on the attribute as a hint for generation tooling. This enables using language specfic objects for concepts like "datetime_t".