### PR TITLE
Preserve version URL prefix in schema links and Swagger API calls

### DIFF
--- a/lib/schema_web/controllers/page_controller.ex
+++ b/lib/schema_web/controllers/page_controller.ex
@@ -122,7 +122,7 @@ defmodule SchemaWeb.PageController do
   """
   @spec base_event(Plug.Conn.t(), any) :: Plug.Conn.t()
   def base_event(conn, _params) do
-    redirect(conn, to: "/classes/base_event")
+    redirect(conn, to: Routes.static_path(conn, "/classes/base_event"))
   end
 
   @spec objects(Plug.Conn.t(), map()) :: Plug.Conn.t()

--- a/lib/schema_web/templates/layout/app.html.eex
+++ b/lib/schema_web/templates/layout/app.html.eex
@@ -301,7 +301,7 @@ limitations under the License.
       <li id="resources_id" class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="javascript:void(0)" role="button">Resources</a>
         <div class="dropdown-content">
-          <a class="dropdown-link" target="_blank" href='<%= Routes.static_path(@conn, "/doc") %>'>API Documentation</a>
+          <a class="dropdown-link" target="_blank" href='<%= Routes.static_path(@conn, "/doc/index.html") %>'>API Documentation</a>
           <a class="dropdown-link" target="_blank" href="https://github.com/ocsf/ocsf-docs/blob/main/overview/understanding-ocsf.md">Understanding OCSF</a>
           <a class="dropdown-link" target="_blank" href="https://github.com/ocsf/ocsf-docs/tree/main/faqs">FAQ</a>
           <a class="dropdown-link" target="_blank" href="https://github.com/ocsf/examples/tree/main">Example Mappings</a>

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "4.3.0"
+  @version "4.4.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -258,10 +258,13 @@ function searchInCategories(filter) {
 }
 
 function init_schema_buttons() {
-  // Strip any version prefix (e.g. /1.3.0) from the pathname so the
-  // /sample, /schema, and /api routes resolve correctly when the server
-  // is fronted by a versioned URL prefix.
-  const basePath = window.location.pathname.replace(/^\/[\d.]+(?:-[^\/]+)?/, '');
+  // Split any version prefix (e.g. /1.8.0) from the rest of the path so the
+  // /sample, /schema, and /api routes can be requested under the same prefix
+  // the page is served from. Without a prefix, versionPrefix is empty and
+  // the routes resolve at the root as before.
+  const prefixMatch = window.location.pathname.match(/^(\/[\d.]+(?:-[^\/]+)?)?(\/.*)$/);
+  const versionPrefix = (prefixMatch && prefixMatch[1]) || '';
+  const basePath = (prefixMatch && prefixMatch[2]) || window.location.pathname;
 
   function buttonParams() {
     const extensions = get_selected_extensions();
@@ -270,19 +273,19 @@ function init_schema_buttons() {
   }
 
   $('#btn-sample-data').on('click', function(event) {
-    window.open('/sample' + basePath + buttonParams(), '_blank');
+    window.open(versionPrefix + '/sample' + basePath + buttonParams(), '_blank');
   });
 
   $('#btn-json-schema').on('click', function(event) {
-    window.open('/schema' + basePath + buttonParams(), '_blank');
+    window.open(versionPrefix + '/schema' + basePath + buttonParams(), '_blank');
   });
 
   $('#btn-schema').on('click', function(event) {
-    window.open('/api' + basePath + buttonParams(), '_blank');
+    window.open(versionPrefix + '/api' + basePath + buttonParams(), '_blank');
   });
 
   $('#btn-validate').on('click', function(event) {
-    window.open('/doc/index.html#/Tools/SchemaWeb.SchemaController.validate2', '_blank');
+    window.open(versionPrefix + '/doc/index.html#/Tools/SchemaWeb.SchemaController.validate2', '_blank');
   });
 }
 

--- a/priv/static/js/visualizer.js
+++ b/priv/static/js/visualizer.js
@@ -3,7 +3,10 @@
 // ─── Config ──────────────────────────────────────────────────────────────────
 
 const CURRENT_ORIGIN = window.location.origin;
-const API = `${CURRENT_ORIGIN}/api`;
+// Preserve any version prefix (e.g. /1.8.0) the page is served under so API
+// calls resolve under the same prefix. Empty when served at the root.
+const VERSION_PREFIX = (window.location.pathname.match(/^(\/[\d.]+(?:-[^\/]+)?)\//) || [])[1] || '';
+const API = `${CURRENT_ORIGIN}${VERSION_PREFIX}/api`;
 
 // Forward current extension/profile selection to API calls
 function getSchemaFilterParams() {


### PR DESCRIPTION
When the server is served under a version path prefix (e.g. /1.8.0), several links and client-side requests dropped the prefix, producing URLs that were not routable and failed.

- page_controller: base_event redirect now uses Routes.static_path so the /classes/base_event target keeps the prefix
- app.js: JSON Schema, Sample, API, and validate buttons now build URLs under the current version prefix instead of stripping it
- app.html.eex: API Documentation link points at /doc/index.html directly, avoiding the prefix-dropping SwaggerUI redirect
- visualizer.js: API base URL includes the version prefix so graph data loads under the prefix

Bump version to 4.4.0.