### PR TITLE
Content-Link Prefix Awareness

### DIFF
--- a/lib/schema_web/templates/layout/app.html.eex
+++ b/lib/schema_web/templates/layout/app.html.eex
@@ -64,8 +64,9 @@ limitations under the License.
           if (!href || href.startsWith('http') || href.startsWith('#') || href.startsWith('javascript:')) {
             return;
           }
+          const schemaPath = href.replace(/^\/[\d.]+(?:-[^\/]+)?(?=\/)/, '');
           // Only update internal schema navigation links
-          if (href.match(/^\/(classes|objects|categories|profiles|dictionary|data_types|visualizer)/)) {
+          if (schemaPath.match(/^\/(classes|objects|categories|profiles|dictionary|data_types|visualizer)(?:\/|\?|$)/)) {
             const joiner = href.includes('?') ? '&' : '';
             this.href = this.href + (joiner ? params.replace('?', '&') : params);
           }


### PR DESCRIPTION
Realized by: https://github.com/ocsf/ocsf-server/pull/187 [(source thread)](https://github.com/ocsf/ocsf-server/pull/187#discussion_r3641544974)

## Summary
Makes page-body schema content links version-prefix aware when preserving selected `extensions` and `profiles` query params.

Previously, the matcher only recognized unprefixed paths like `/classes/...` and `/objects/...`, so links rendered under a version prefix such as `/1.8.0/classes/...` skipped query-param propagation. This normalizes the path only for matching while preserving the original href.

  ## Validation

  - `mix test --no-start`
  - JS matcher sanity check for prefixed and unprefixed schema links

Before: version-prefixed schema content links did not match, so selected filter params were not appended:

<img width="795" height="376" alt="image" src="https://github.com/user-attachments/assets/e86f9751-4b6c-4598-9007-5bbc431bf21c" />

After: the matcher normalizes the version prefix for matching and preserves `extensions` / `profiles` on the original link.

<img width="1087" height="381" alt="image" src="https://github.com/user-attachments/assets/83a40481-ae97-4701-9d00-e4c3ee2bc7bc" />

Note: I did not roll the version from `4.4.0`. If we think that's necessary I can do so but PR #187 was so close that I debated whether really necessary. Will defer to reviewers.