### PR TITLE
Render supersedes and replaced-by notes for deprecations

### DIFF
--- a/lib/schema.ex
+++ b/lib/schema.ex
@@ -230,6 +230,16 @@ defmodule Schema do
     SingleRepo.classes()
   end
 
+  @doc """
+  Returns all event classes (with browser information) filtered by extensions.
+  This is meant for the classes HTML page, which needs browser-only metadata such
+  as :_supersedes. Mirrors objects_filter_extensions/1.
+  """
+  @spec classes_filter_extensions(Utils.string_set_t() | nil) :: map()
+  def classes_filter_extensions(extensions) do
+    SingleRepo.classes() |> Utils.filter_items_by_extensions(extensions)
+  end
+
   @spec clean_classes_filter_extensions(Utils.string_set_t() | nil) :: map()
   def clean_classes_filter_extensions(extensions) do
     SingleRepo.clean_classes() |> Utils.filter_items_by_extensions(extensions)

--- a/lib/schema_web/controllers/page_controller.ex
+++ b/lib/schema_web/controllers/page_controller.ex
@@ -84,9 +84,11 @@ defmodule SchemaWeb.PageController do
 
   @spec classes(Plug.Conn.t(), any) :: Plug.Conn.t()
   def classes(conn, params) do
+    params = Map.put_new(params, "extensions", "")
+
     data =
-      Map.put_new(params, "extensions", "")
-      |> SchemaController.classes()
+      SchemaController.parse_options(SchemaController.extensions(params))
+      |> Schema.classes_filter_extensions()
       |> sort_by(:uid)
 
     render(conn, "classes.html",

--- a/lib/schema_web/templates/page/class.html.eex
+++ b/lib/schema_web/templates/page/class.html.eex
@@ -51,6 +51,7 @@ limitations under the License.
     <div class="text-secondary description-content">
       <%= raw description(@data) %>
     </div>
+    <%= raw format_item_supersedes(@conn, @data, "classes") %>
     <%= if has_deprecated_attributes?(@data) do %>
     <% dep_count = deprecated_attributes_count(@data) %>
     <div class="deprecated-attr-notice" id="deprecated-attr-notice">
@@ -120,7 +121,7 @@ limitations under the License.
           <td class="capitalize"><%= attribute[:group] %></td>
           <td><%= raw format_requirement(constraints, attribute_key, attribute) %></td>
           <td class="extensions"><%= raw format_type(@conn, attribute) %></td>
-          <td><%= raw format_attribute_desc(attribute_key, attribute) %></td>
+          <td><%= raw format_attribute_desc(attribute_key, attribute, @conn) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/lib/schema_web/templates/page/classes.html.eex
+++ b/lib/schema_web/templates/page/classes.html.eex
@@ -44,7 +44,7 @@ limitations under the License.
           <% else %>
             <td></td>
           <% end %>
-          <td><%= raw description(class) %></td>
+          <td><%= raw description(class) %><%= raw format_item_supersedes(@conn, class, "classes") %></td>
         </tr>
       <% end %>
     </tbody>

--- a/lib/schema_web/templates/page/data_types.html.eex
+++ b/lib/schema_web/templates/page/data_types.html.eex
@@ -17,6 +17,12 @@ limitations under the License.
     <div class="text-secondary description-content">
       <%= raw @data[:description] %>
     </div>
+    <%= raw object_references_section([
+      %{
+        url: "https://github.com/ocsf/ocsf-docs/blob/main/articles/OCSF-Storage-Strategies.md#data-type-mappings",
+        description: "Data Type Mappings (storage formats, e.g. Apache Iceberg)"
+      }
+    ]) %>
   </div>
 </div>
 

--- a/lib/schema_web/templates/page/dictionary.html.eex
+++ b/lib/schema_web/templates/page/dictionary.html.eex
@@ -53,7 +53,7 @@ limitations under the License.
           <td><%= raw format_attribute_caption(@conn, @schema, attribute_key, attribute) %></td>
           <td class="extensions"><%= raw format_type(@conn, attribute) %></td>
           <td class="extensions"><%= raw dictionary_links(@conn, @schema, attribute_key, attribute[:_links]) %></td>
-          <td><%= raw format_dictionary_attribute_desc(attribute_key, attribute) %></td>
+          <td><%= raw format_dictionary_attribute_desc(attribute_key, attribute, @conn) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/lib/schema_web/templates/page/object.html.eex
+++ b/lib/schema_web/templates/page/object.html.eex
@@ -46,6 +46,7 @@ limitations under the License.
     <div class="text-secondary description-content">
       <%= raw description(@data) %>
     </div>
+    <%= raw format_item_supersedes(@conn, @data, "objects") %>
     <%= if has_deprecated_attributes?(@data) do %>
     <% dep_count = deprecated_attributes_count(@data) %>
     <div class="deprecated-attr-notice" id="deprecated-attr-notice">
@@ -100,7 +101,7 @@ limitations under the License.
         <td><%= raw format_attribute_caption(@conn, @schema, attribute_key, attribute) %></td>
         <td><%= raw format_requirement(constraints, attribute_key, attribute) %></td>
         <td class="extensions"><%= raw format_type(@conn, attribute) %></td>
-        <td><%= raw format_attribute_desc(attribute_key, attribute) %></td>
+        <td><%= raw format_attribute_desc(attribute_key, attribute, @conn) %></td>
       </tr>
       <% end %>
     </tbody>

--- a/lib/schema_web/templates/page/objects.html.eex
+++ b/lib/schema_web/templates/page/objects.html.eex
@@ -45,7 +45,7 @@ limitations under the License.
           <td class="name"><a href="<%= object_path %>"><%= object_key_str %></a></td>
           <td class="extensions"><%= raw format_attribute_caption(@conn, @schema, object_key_str, object, false) %></td>
           <td class="extensions"><%= raw object_links(@conn, object[:name], object[:_links], :collapse) %></td>
-          <td><%= raw description(object) %></td>
+          <td><%= raw description(object) %><%= raw format_item_supersedes(@conn, object, "objects") %></td>
         </tr>
       <% end %>
     </tbody>

--- a/lib/schema_web/templates/page/profile.html.eex
+++ b/lib/schema_web/templates/page/profile.html.eex
@@ -80,7 +80,7 @@ limitations under the License.
         <td class="capitalize"><%= field[:group] %></td>
         <td><%= raw format_requirement(nil, key, field) %></td>
         <td><%= raw format_type(@conn, field) %></td>
-        <td><%= raw format_attribute_desc(key, field) %></td>
+        <td><%= raw format_attribute_desc(key, field, @conn) %></td>
       </tr>
       <% end %>
     </tbody>

--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -672,20 +672,34 @@ defmodule SchemaWeb.PageView do
     end
   end
 
-  @spec format_attribute_desc(String.t() | atom(), map()) :: any
-  def format_attribute_desc(attribute_key, attribute) do
-    append_source_references(
-      base_format_attribute_desc(attribute_key, attribute, false),
-      "<p><hr>",
+  @spec format_attribute_desc(String.t() | atom(), map(), Plug.Conn.t() | nil) :: any
+  def format_attribute_desc(attribute_key, attribute, conn \\ nil) do
+    append_supersedes(
+      append_superseded_by(
+        append_source_references(
+          base_format_attribute_desc(attribute_key, attribute, false),
+          "<p><hr>",
+          attribute
+        ),
+        attribute,
+        conn
+      ),
       attribute
     )
   end
 
-  @spec format_dictionary_attribute_desc(String.t() | atom(), map()) :: any
-  def format_dictionary_attribute_desc(attribute_key, attribute) do
-    append_source_references(
-      base_format_attribute_desc(attribute_key, attribute, true),
-      "<p><hr>",
+  @spec format_dictionary_attribute_desc(String.t() | atom(), map(), Plug.Conn.t() | nil) :: any
+  def format_dictionary_attribute_desc(attribute_key, attribute, conn \\ nil) do
+    append_supersedes(
+      append_superseded_by(
+        append_source_references(
+          base_format_attribute_desc(attribute_key, attribute, true),
+          "<p><hr>",
+          attribute
+        ),
+        attribute,
+        conn
+      ),
       attribute
     )
   end
@@ -745,6 +759,7 @@ defmodule SchemaWeb.PageView do
                 Map.get(item, :caption, id),
                 "<div class=\"text-secondary\">",
                 append_source_references(description(item), item),
+                format_enum_supersedes(item, enum_values),
                 "</div></td><tr>" | acc
               ]
             end
@@ -817,6 +832,168 @@ defmodule SchemaWeb.PageView do
       [html, prefix_html, refs_html]
     else
       html
+    end
+  end
+
+  # Appends a "Supersedes" note when this (non-deprecated) attribute replaces one or
+  # more deprecated attributes. The reverse reference is precomputed by the schema
+  # compiler in browser mode as the :_supersedes marker. Unlike the deprecation notice,
+  # this is shown by default so consumers migrating off a deprecated attribute can
+  # discover its replacement from the live attribute.
+  @spec append_supersedes(any(), map()) :: any()
+  defp append_supersedes(html, attribute) do
+    case attribute[:_supersedes] do
+      supersedes when is_list(supersedes) and supersedes != [] ->
+        [html, format_supersedes(supersedes)]
+
+      _ ->
+        html
+    end
+  end
+
+  @spec format_supersedes([map()]) :: any()
+  defp format_supersedes(supersedes) do
+    names =
+      supersedes
+      |> Enum.map(fn entry -> entry[:type] end)
+      |> Enum.map(fn name ->
+        ["<code>", Phoenix.HTML.html_escape(name) |> Phoenix.HTML.safe_to_string(), "</code>"]
+      end)
+      |> Enum.intersperse(", ")
+
+    [
+      "<div class='supersedes-note mt-2'><i class='fas fa-arrow-right'></i> Supersedes deprecated ",
+      names,
+      "</div>"
+    ]
+  end
+
+  # Appends a "Replaced by" forward link on a DEPRECATED attribute whose replacement
+  # lives in another object or class (a dotted path in @deprecated.superseded_by, e.g.
+  # "job_action.cmd_line"). Renders each replacement path as a link to the target's
+  # page. conn is required to build URLs; when nil (callers that don't pass it) nothing
+  # is appended. Same-scope replacements are handled by the reverse note instead.
+  @spec append_superseded_by(any(), map(), Plug.Conn.t() | nil) :: any()
+  defp append_superseded_by(html, _attribute, nil), do: html
+
+  defp append_superseded_by(html, attribute, conn) do
+    deprecated = attribute[:"@deprecated"]
+
+    superseded_by =
+      if is_map(deprecated), do: deprecated[:superseded_by], else: nil
+
+    case superseded_by do
+      paths when is_list(paths) and paths != [] ->
+        # Only render forward links for cross-container (dotted path) replacements.
+        cross = Enum.filter(paths, fn p -> String.contains?(to_string(p), ".") end)
+
+        if cross == [] do
+          html
+        else
+          [html, format_superseded_by(cross, conn)]
+        end
+
+      _ ->
+        html
+    end
+  end
+
+  @spec format_superseded_by([String.t()], Plug.Conn.t()) :: any()
+  defp format_superseded_by(paths, conn) do
+    links =
+      paths
+      |> Enum.map(fn path -> superseded_by_link(to_string(path), conn) end)
+      |> Enum.intersperse(", ")
+
+    [
+      "<div class='superseded-by-note mt-2'><i class='fas fa-arrow-right'></i> Replaced by ",
+      links,
+      "</div>"
+    ]
+  end
+
+  # Builds a link to the replacement attribute's containing class or object page.
+  # The path's first segment names the container; if it resolves to a class it links
+  # to /classes/<name>, otherwise to /objects/<name>. The full path is shown as the
+  # link text.
+  @spec superseded_by_link(String.t(), Plug.Conn.t()) :: any()
+  defp superseded_by_link(path, conn) do
+    base = path |> String.split(".") |> hd() |> String.split("[") |> hd()
+    escaped = Phoenix.HTML.html_escape(path) |> Phoenix.HTML.safe_to_string()
+
+    kind = if Schema.class(base) != nil, do: "classes", else: "objects"
+    href = SchemaWeb.Router.Helpers.static_path(conn, "/#{kind}/#{base}")
+    ["<a href=\"", href, "\"><code>", escaped, "</code></a>"]
+  end
+
+  # Renders a "Supersedes" note for an enum value that replaces one or more deprecated
+  # enum values of the same attribute. The :_supersedes marker (precomputed by the
+  # compiler in browser mode) holds the deprecated enum value keys; enum_values is the
+  # full enum map, used to look up each deprecated value's caption for display.
+  @spec format_enum_supersedes(map(), map() | list()) :: any()
+  defp format_enum_supersedes(item, enum_values) do
+    case item[:_supersedes] do
+      supersedes when is_list(supersedes) and supersedes != [] ->
+        labels =
+          supersedes
+          |> Enum.map(fn entry -> to_string(entry[:type]) end)
+          |> Enum.map(fn key ->
+            caption = enum_value_caption(enum_values, key)
+            escaped = Phoenix.HTML.html_escape(caption) |> Phoenix.HTML.safe_to_string()
+            ["<code>", escaped, "</code> [", key, "]"]
+          end)
+          |> Enum.intersperse(", ")
+
+        [
+          "<div class='supersedes-note mt-2'><i class='fas fa-arrow-right'></i> Supersedes deprecated ",
+          labels,
+          "</div>"
+        ]
+
+      _ ->
+        ""
+    end
+  end
+
+  @spec enum_value_caption(map() | list(), String.t()) :: String.t()
+  defp enum_value_caption(enum_values, key) do
+    entry =
+      Enum.find_value(enum_values, nil, fn {k, v} ->
+        if to_string(k) == key, do: v, else: nil
+      end)
+
+    case entry do
+      nil -> key
+      value -> Map.get(value, :caption, key)
+    end
+  end
+
+  # Renders a "Supersedes" note for a whole class or object that replaces one or more
+  # deprecated classes/objects. The :_supersedes marker is precomputed by the schema
+  # compiler in browser mode. kind is "classes" or "objects" (the route segment), used
+  # to link each deprecated item to its page. Shown by default on the live item's page.
+  @spec format_item_supersedes(any(), map(), String.t()) :: any()
+  def format_item_supersedes(conn, item, kind) do
+    case item[:_supersedes] do
+      supersedes when is_list(supersedes) and supersedes != [] ->
+        links =
+          supersedes
+          |> Enum.map(fn entry -> entry[:type] end)
+          |> Enum.map(fn name ->
+            path = SchemaWeb.Router.Helpers.static_path(conn, "/#{kind}/#{name}")
+            escaped = Phoenix.HTML.html_escape(name) |> Phoenix.HTML.safe_to_string()
+            ["<a href=\"", path, "\"><code>", escaped, "</code></a>"]
+          end)
+          |> Enum.intersperse(", ")
+
+        [
+          "<div class='supersedes-note mt-2'><i class='fas fa-arrow-right'></i> Supersedes deprecated ",
+          links,
+          "</div>"
+        ]
+
+      _ ->
+        ""
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "4.4.0"
+  @version "4.5.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/priv/static/css/components.css
+++ b/priv/static/css/components.css
@@ -883,3 +883,60 @@ button:hover,
 [data-theme="dark"] .deprecated-attr-notice i {
   color: #FBBF24;
 }
+
+.supersedes-note {
+  display: block;
+  background: rgba(8, 145, 178, 0.06);
+  border-left: 3px solid var(--accent-color);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.8;
+}
+
+.supersedes-note i {
+  color: var(--accent-color);
+  font-size: var(--text-sm);
+  margin-right: var(--spacing-sm);
+}
+
+.supersedes-note code {
+  background: transparent;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.superseded-by-note {
+  display: block;
+  background: rgba(217, 119, 6, 0.06);
+  border-left: 3px solid var(--warning-color);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.8;
+}
+
+.superseded-by-note i {
+  color: var(--warning-color);
+  font-size: var(--text-sm);
+  margin-right: var(--spacing-sm);
+}
+
+.superseded-by-note code {
+  background: transparent;
+  padding: 0;
+  white-space: nowrap;
+}
+
+[data-theme="dark"] .superseded-by-note {
+  background: rgba(251, 191, 36, 0.06);
+  border-left-color: #FBBF24;
+}
+
+[data-theme="dark"] .superseded-by-note i {
+  color: #FBBF24;
+}


### PR DESCRIPTION
## Summary

Surfaces deprecation replacements in the schema browser, in both directions.

The OCSF `@deprecated` block now carries a `superseded_by` array naming the replacement definition(s), and the schema compiler derives a reverse `_supersedes` marker on each replacement in browser mode. This PR renders both:

- **"Supersedes deprecated X"** on a live definition — so anyone landing on the replacement can see what it took over from.
- **"Replaced by X"** on a deprecated attribute whose replacement lives in a *different* container — so consumers migrating off it can find where it went, without hunting through other pages.

Depends on the schema-side and compiler-side changes (see Related below). Renders nothing when the marker is absent, so it is a no-op against a schema compiled without them.

## Changes

**`page_view.ex`**
- `format_item_supersedes/3` — the note for a whole class or object, linking each superseded item to its page.
- `append_supersedes/2` — the note for an attribute.
- `format_enum_supersedes/2` — the note for an enum value, resolving the deprecated value's caption for display alongside its key.
- `append_superseded_by/3` — the forward "Replaced by" note. Only dotted paths (e.g. `job_action.cmd_line`) get a link, since same-context replacements are already covered by the reverse note. The link targets the container page, resolving `classes` vs `objects` via `Schema.class/1`.
- `format_attribute_desc/3` and `format_dictionary_attribute_desc/3` take an optional `conn` to build those links. It defaults to `nil`, and `append_superseded_by/3` returns the html untouched in that case, so any caller that doesn't pass it keeps working.

**`schema.ex` / `page_controller.ex`** — the classes listing page went through `clean_classes_filter_extensions/1`. `Utils.filter_internal/1` strips every `_`-prefixed key, so `_supersedes` never reached the template. Adds `classes_filter_extensions/1` and points the page at it, mirroring `objects_filter_extensions/1`, which the objects listing page already uses for the same reason.

Note on the controller: the previous path applied attribute-level profile filtering via `clean_classes_filter_extensions_profiles/2`. Dropping it is not a regression and brings `classes/2` to parity with `objects/2` — `filter_items_attributes_by_profiles/2` filters only *attributes*, and the classes listing renders no attribute rows. The per-row profile data driving the client-side filter comes from `class[:profiles]`, which is untouched.

**`data_types.html.eex`** — links out to the OCSF storage strategies data type mappings article.

**`components.css`** — styles both notes (accent color for supersedes, warning color for replaced-by), with dark-theme variants.

Bumps version to 4.5.0.

## Testing

`mix compile` clean (the `unused require Logger` warning in `lib/schema.ex` is pre-existing on `main`). `mix format --check-formatted` reports the same three files as `main` does; no new findings, and the formatter's suggestions fall entirely on pre-existing lines.

Ran the server against a browser-mode compile of `ocsf-schema` and verified every rendering surface:

| Surface | Verified |
|---|---|
| Class page | `_supersedes` note above the attribute table |
| Object page | e.g. `finding_info` → links to `finding` |
| Classes listing | 10 notes, matching the compiled count |
| Objects listing | 3 notes, matching the compiled count |
| Attribute rows | 179 across class/object/profile pages |
| Dictionary | 36 supersedes, 12 replaced-by |
| Enum value | `win/reg_value` `type_id` 8 → `REG_QWORD_LITTLE_ENDIAN [9]` |
| Profile page | `incident`, `data_classification`, `network_proxy` |
| Cross-container links | 23, e.g. `job.cmd_line` → `/objects/job_action` |
| Data types page | storage strategies link present |

Also spot-checked `/`, `/classes`, `/objects`, `/dictionary`, `/data_types`, `/profiles`, `/categories`, `/classes/authentication`, `/objects/user` — all 200, and `/base_event` 302 as expected. Multi-item notes render comma-separated (e.g. `cis_benchmark`, plus others).

Marker counts match the compiler output exactly in every case, confirming nothing is dropped between compile and render.

## Related

- ocsf/ocsf-schema#1707 — adds `superseded_by` across the schema
- ocsf/ocsf-schema-compiler#19 — derives the reverse `_supersedes` marker
- ocsf/ocsf-validator#39 — recognizes the new key