### PR TITLE
Adding capability to collapse Enums, fix a latent column width bug

### DIFF
--- a/lib/schema_web/views/page_view.ex
+++ b/lib/schema_web/views/page_view.ex
@@ -8,6 +8,9 @@ defmodule SchemaWeb.PageView do
   @unknown_constraint_symbol "*"
   @enum_attributes_doc_url "https://github.com/ocsf/ocsf-docs/blob/main/overview/understanding-ocsf.md#enum-attributes"
 
+  # Number of enum values rendered up front; the rest are hidden behind a toggle.
+  @enum_values_display_limit 6
+
 
   def class_path(conn, data) do
     class_name = data[:name]
@@ -737,34 +740,20 @@ defmodule SchemaWeb.PageView do
             Enum.sort(enum_values, fn {k1, _}, {k2, _} -> k1 >= k2 end)
           end
 
-        [
-          "<table class=\"mt-1 table-borderless\"><tbody>",
-          Enum.reduce(
-            sorted,
-            [],
-            fn {id, item}, acc ->
-              id = to_string(id)
-              css_classes = show_deprecated_css_classes(item, "bg-transparent")
+        # The rows are sorted in descending order and displayed in ascending order.
+        displayed = Enum.reverse(sorted)
 
-              [
-                "<tr class=\"",
-                css_classes,
-                "\"><td style=\"width: 25px\" class=\"text-right\" id=\"",
-                to_string(attribute_key),
-                "-",
-                id,
-                "\"><code>",
-                id,
-                "</code></td><td class=\"textnowrap\">",
-                Map.get(item, :caption, id),
-                "<div class=\"text-secondary\">",
-                append_source_references(description(item), item),
-                format_enum_supersedes(item, enum_values),
-                "</div></td><tr>" | acc
-              ]
-            end
-          ),
-          "</tbody></table>"
+        [
+          "<div class=\"enum-values\">",
+          "<table class=\"mt-1 table-borderless\"><tbody>",
+          displayed
+          |> Enum.with_index()
+          |> Enum.map(fn {{id, item}, index} ->
+            enum_value_row(attribute_key, id, item, enum_values, index)
+          end),
+          "</tbody></table>",
+          enum_values_toggle(length(displayed)),
+          "</div>"
         ]
       else
         ""
@@ -791,6 +780,53 @@ defmodule SchemaWeb.PageView do
           "enum attribute</a>.</small></div>"
         ]
       end
+    ]
+  end
+
+  # Rows past @enum_values_display_limit are marked "enum-value-extra d-none" and are
+  # revealed by the toggle rendered by enum_values_toggle/1. A row that is both extra and
+  # deprecated stays hidden until both the toggle and "show deprecated" are on.
+  defp enum_value_row(attribute_key, id, item, enum_values, index) do
+    id = to_string(id)
+
+    initial_css_classes =
+      if index < @enum_values_display_limit do
+        "bg-transparent"
+      else
+        "bg-transparent enum-value-extra d-none"
+      end
+
+    [
+      "<tr class=\"",
+      show_deprecated_css_classes(item, initial_css_classes),
+      "\"><td style=\"width: 25px\" class=\"text-right\" id=\"",
+      to_string(attribute_key),
+      "-",
+      id,
+      "\"><code>",
+      id,
+      "</code></td><td class=\"textnowrap\">",
+      Map.get(item, :caption, id),
+      "<div class=\"text-secondary\">",
+      append_source_references(description(item), item),
+      format_enum_supersedes(item, enum_values),
+      "</div></td><tr>"
+    ]
+  end
+
+  @spec enum_values_toggle(non_neg_integer()) :: any()
+  defp enum_values_toggle(total_count) when total_count <= @enum_values_display_limit, do: ""
+
+  defp enum_values_toggle(total_count) do
+    show_all_label = "Show all #{total_count} values"
+
+    [
+      "<a href=\"#\" class=\"enum-values-toggle small\" onclick=\"return toggle_enum_values(this)\"",
+      " data-more-label=\"",
+      show_all_label,
+      "\" data-less-label=\"Show fewer values\">",
+      show_all_label,
+      "</a>"
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@
 defmodule Schema.MixProject do
   use Mix.Project
 
-  @version "4.5.0"
+  @version "4.6.0"
 
   def project do
     build = System.get_env("GITHUB_RUN_NUMBER") || "SNAPSHOT"

--- a/priv/static/css/components.css
+++ b/priv/static/css/components.css
@@ -884,6 +884,33 @@ button:hover,
   color: #FBBF24;
 }
 
+.enum-values-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  color: var(--primary-color);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.enum-values-toggle:hover {
+  color: var(--accent-color);
+  text-decoration: underline;
+}
+
+.enum-values-toggle::after {
+  content: '\f078';
+  font-family: 'Font Awesome 6 Free';
+  font-weight: 900;
+  font-size: var(--text-xs);
+}
+
+.enum-values-toggle[data-expanded="true"]::after {
+  content: '\f077';
+}
+
 .supersedes-note {
   display: block;
   background: rgba(8, 145, 178, 0.06);

--- a/priv/static/css/tables.css
+++ b/priv/static/css/tables.css
@@ -128,6 +128,13 @@ table .description-column {
   white-space: normal;
 }
 
+/* Bootstrap sets white-space: nowrap on .dropdown-toggle. In table cells that makes
+   the collapse toggles, such as "Updated in 79 classes (22 deprecated)" in the
+   dictionary "Referenced By" column, overflow into the neighboring column. */
+table td a.dropdown-toggle {
+  white-space: normal;
+}
+
 /* Code elements in table description columns should wrap */
 table td code,
 .col-description code,

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -393,6 +393,47 @@ function smoothShowDeprecated(show) {
   });
 }
 
+/* Enum values past the first few are rendered hidden; this reveals or re-hides them. */
+function toggle_enum_values(link) {
+  const container = link.closest('.enum-values');
+
+  if (container) {
+    const expanded = link.getAttribute('data-expanded') === 'true';
+
+    container.querySelectorAll('tr.enum-value-extra').forEach(function (row) {
+      row.classList.toggle('d-none', expanded);
+    });
+
+    link.setAttribute('data-expanded', expanded ? 'false' : 'true');
+    link.textContent = expanded
+      ? link.getAttribute('data-more-label')
+      : link.getAttribute('data-less-label');
+  }
+
+  return false;
+}
+
+/* Deep links can point at a hidden enum value, e.g. /objects/observable#type_id-13. */
+function expand_enum_values_for_hash() {
+  const hash = window.location.hash;
+
+  if (hash.length < 2) {
+    return;
+  }
+
+  const target = document.getElementById(decodeURIComponent(hash.substring(1)));
+  const row = target ? target.closest('tr.enum-value-extra') : null;
+
+  if (row) {
+    const toggle = row.closest('.enum-values').querySelector('.enum-values-toggle');
+
+    if (toggle && toggle.getAttribute('data-expanded') !== 'true') {
+      toggle_enum_values(toggle);
+      target.scrollIntoView();
+    }
+  }
+}
+
 function updateShowDeprecatedState(isActive) {
   const container = document.querySelector('.show-deprecated-container');
   if (container) {
@@ -569,6 +610,9 @@ document.addEventListener('DOMContentLoaded', function() {
   
   // Initialize sidebar toggle
   initSidebarToggle();
+
+  expand_enum_values_for_hash();
+  window.addEventListener('hashchange', expand_enum_values_for_hash);
   
   
   // Enhance search input with focus styling


### PR DESCRIPTION
### Related Issue: #190 

### Summary of changes:
1. Enums: class, object, profile, and dictionary pages now show the first 6 enum values, with a Show all N values / Show fewer values toggle for the rest. Deep links into a hidden value (for example /objects/observable#type_id-13) expand that list and scroll to the row. Deprecated values stay behind the existing “show deprecated” control; a value that is both extra and deprecated only appears when both toggles are on.

2. Dictionary layout: “Referenced By” collapse labels no longer overflow into Description. Bootstrap’s .dropdown-toggle { white-space: nowrap } was stretching strings like Updated in 79 classes 

3. Version: bump to 4.6.0.